### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/src/test/java/org/mule/extension/ws/runtime/SoapFaultTestCase.java
+++ b/src/test/java/org/mule/extension/ws/runtime/SoapFaultTestCase.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertThat;
 
 import org.mule.extension.ws.AbstractSoapServiceTestCase;
 import org.mule.runtime.api.message.Error;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 import org.mule.runtime.soap.api.exception.BadRequestException;
 import org.mule.runtime.soap.api.exception.SoapFaultException;
 import org.mule.tck.junit4.matcher.ErrorTypeMatcher;

--- a/src/test/java/org/mule/extension/ws/runtime/transport/HttpBasicAuthConfigTestCase.java
+++ b/src/test/java/org/mule/extension/ws/runtime/transport/HttpBasicAuthConfigTestCase.java
@@ -20,7 +20,7 @@ import static org.mule.tck.junit4.matcher.ErrorTypeMatcher.errorType;
 import org.mule.extension.ws.AbstractSoapServiceTestCase;
 import org.mule.runtime.api.message.Error;
 import org.mule.runtime.api.message.Message;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import org.apache.cxf.transport.servlet.CXFNonSpringServlet;
 import org.eclipse.jetty.security.ConstraintMapping;


### PR DESCRIPTION
MULE-10370: Remove custom-exception-strategy element

_ Moving classes from org.mule.runtime.core.extension to api/internal
_ Temporarily exporting org.mule.runtime.core.internal.extension (because MULE-12427)
_ Adding test:exception-strategy for tests to replace mule:custom-exception-strategy
_ Removing mule:custom-exception-strategy element