### PR TITLE
Revert "MDM-80: Metadatatype serialization should not be so heavy (#1…

### DIFF
--- a/src/test/java/org/mule/extension/ws/metadata/OutputMetadataTestCase.java
+++ b/src/test/java/org/mule/extension/ws/metadata/OutputMetadataTestCase.java
@@ -54,7 +54,7 @@ public class OutputMetadataTestCase extends AbstractMetadataTestCase {
     ObjectFieldType body = operationFields.iterator().next();
     Collection<ObjectFieldType> bodyFields = toObjectType(body.getValue()).getFields();
     ObjectFieldType echo = bodyFields.iterator().next();
-    assertThat(echo.getKey().getName().toString(), containsString("{http://service.soap.service.mule.org/}echoResponse"));
+    assertThat(echo.getKey().getName().toString(), containsString("{http://service.ws.extension.mule.org/}echoResponse"));
     ObjectType echoType = toObjectType(echo.getValue());
     Collection<ObjectFieldType> echoFields = echoType.getFields();
     assertThat(echoFields, hasSize(1));

--- a/src/test/resources/config/metadata.xml
+++ b/src/test/resources/config/metadata.xml
@@ -5,9 +5,10 @@
       http://www.mulesoft.org/schema/mule/wsc http://www.mulesoft.org/schema/mule/wsc/current/mule-wsc.xsd">
 
     <wsc:config name="config">
-        <wsc:connection service="TestService"
+        <wsc:connection address="http://localhost:${servicePort}/server"
+                        service="TestService"
                         port="TestPort"
-                        wsdlLocation="wsdl/simple-service.wsdl"
+                        wsdlLocation="http://localhost:${servicePort}/server?wsdl"
                         soapVersion="${soapVersion}">
         </wsc:connection>
     </wsc:config>

--- a/src/test/resources/wsdl/simple-service.wsdl
+++ b/src/test/resources/wsdl/simple-service.wsdl
@@ -6,8 +6,8 @@
         <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://service.soap.service.mule.org/" attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://service.soap.service.mule.org/">
             <xs:element name="downloadAttachment" type="tns:downloadAttachment"/>
             <xs:element name="downloadAttachmentResponse" type="tns:downloadAttachmentResponse"/>
-            <xs:element name="echo" type="tns:echoType"/>
-            <xs:element name="echoAccount" type="tns:echoAccountType"/>
+            <xs:element name="echo" type="tns:echo"/>
+            <xs:element name="echoAccount" type="tns:echoAccount"/>
             <xs:element name="echoAccountResponse" type="tns:echoAccountResponse"/>
             <xs:element name="echoResponse" type="tns:echoResponse"/>
             <xs:element name="echoWithHeaders" type="tns:echoWithHeaders"/>
@@ -16,14 +16,14 @@
             <xs:element name="failResponse" type="tns:failResponse"/>
             <xs:element name="large" type="tns:large"/>
             <xs:element name="largeResponse" type="tns:largeResponse"/>
-            <xs:element name="noParams" type="tns:noParamsType"/>
+            <xs:element name="noParams" type="tns:noParams"/>
             <xs:element name="noParamsResponse" type="tns:noParamsResponse"/>
             <xs:element name="noParamsWithHeader" type="tns:noParamsWithHeader"/>
             <xs:element name="noParamsWithHeaderResponse" type="tns:noParamsWithHeaderResponse"/>
             <xs:element name="oneWay" type="tns:oneWay"/>
             <xs:element name="uploadAttachment" type="tns:uploadAttachment"/>
             <xs:element name="uploadAttachmentResponse" type="tns:uploadAttachmentResponse"/>
-            <xs:complexType name="echoType">
+            <xs:complexType name="echo">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="text" type="xs:string"/>
                 </xs:sequence>
@@ -83,7 +83,7 @@
                     <xs:element minOccurs="0" name="attachment" type="xs:base64Binary"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="noParamsType">
+            <xs:complexType name="noParams">
                 <xs:sequence/>
             </xs:complexType>
             <xs:complexType name="noParamsResponse">
@@ -99,7 +99,7 @@
                     <xs:element minOccurs="0" name="text" type="xs:string"/>
                 </xs:sequence>
             </xs:complexType>
-            <xs:complexType name="echoAccountType">
+            <xs:complexType name="echoAccount">
                 <xs:sequence>
                     <xs:element minOccurs="0" name="account" type="tns:account"/>
                     <xs:element minOccurs="0" name="name" type="xs:string"/>


### PR DESCRIPTION
…05)"

This reverts commit 469a0ff1dbc7de70648a6564a9688d308cc34ea1.