### PR TITLE
MULE-16765: Fix Mule 4 Status pipelines' failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <validations.module.version>1.1.0</validations.module.version>
         <java.module.version>1.1.1</java.module.version>
         <docker.maven.plugin.version>0.25.2</docker.maven.plugin.version>
+        <docker.skip>${skipTests}</docker.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- `docker-maven-plugin` goals don't need to be run when test are not
going to be executed
- Indeed, this add a somehow unnecessary overhead (at least in terms of
time) to the compile stage in Jenkins
- On the other hand, it also imposes to have Docker installed on the
host machine to simply build the connector, which in some case could be
not that convenient.