### PR TITLE
MULE-16792: Create a Windows Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM fbascheper/soapui-mockservice-runner
-
-COPY src/test/resources/soapui-prj/* /home/soapui/soapui-prj/
-COPY src/test/resources/security/* /home/soapui/security/
-COPY src/test/resources/wsdl/* /home/soapui/wsdl/
-
-COPY src/test/resources/docker-libs/xmlsec-1.5.8.jar /home/soapui/SoapUI-5.4.0/lib/xmlsec-1.4.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <commons.lang.version>3.7</commons.lang.version>
         <guava.version>25.1-jre</guava.version>
         <cxf.version>3.2.1</cxf.version>
-      
+
         <mule.http.connector.version>1.2.0</mule.http.connector.version>
         <soap.engine.version>1.1.2-SNAPSHOT</soap.engine.version>
         <wsdl.parser.version>1.2.6-SNAPSHOT</wsdl.parser.version>
@@ -46,8 +46,12 @@
 
         <validations.module.version>1.1.0</validations.module.version>
         <java.module.version>1.1.1</java.module.version>
-        <docker.maven.plugin.version>0.25.2</docker.maven.plugin.version>
+        <docker.maven.plugin.version>0.30.0</docker.maven.plugin.version>
         <docker.skip>${skipTests}</docker.skip>
+        <dockerfile>Dockerfile</dockerfile>
+        <docker.soapui.container.user.home.url>file:/home/soapui</docker.soapui.container.user.home.url>
+        <docker.soapui.container.user.home.path>/home/soapui</docker.soapui.container.user.home.path>
+        <docker.soapui.container.project.home>/home/soapui/soapui-prj/</docker.soapui.container.project.home>
     </properties>
 
     <dependencies>
@@ -268,6 +272,24 @@
     </pluginRepositories>
 
     <build>
+
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/src/test/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>**/soapui-prj/**</exclude>
+                </excludes>
+            </testResource>
+            <testResource>
+                <directory>${project.basedir}/src/test/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/soapui-prj/**</include>
+                </includes>
+            </testResource>
+        </testResources>
+
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -319,7 +341,7 @@
                         <WS_SOAP12_PORT>${soap12.host.port}</WS_SOAP12_PORT>
                     </environmentVariables>
                 </configuration>
-                    <dependencies>
+                <dependencies>
                     <dependency>
                         <groupId>com.mulesoft.munit</groupId>
                         <artifactId>munit-runner</artifactId>
@@ -360,12 +382,14 @@
                         <image>
                             <name>ws-simple</name>
                             <build>
-                                <dockerFileDir>${project.basedir}</dockerFileDir>
+                                <!--TODO: Improve the way we locate and handle paths referencing-->
+                                <contextDir>${project.build.testOutputDirectory}</contextDir>
+                                <dockerFile>${project.build.testOutputDirectory}/${dockerfile}</dockerFile>
                             </build>
                             <run>
                                 <env>
                                     <MOCK_SERVICE_NAME>MUnitServiceMock</MOCK_SERVICE_NAME>
-                                    <PROJECT>/home/soapui/soapui-prj/simple-service-soapui-project.xml</PROJECT>
+                                    <PROJECT>${docker.soapui.container.project.home}simple-service-soapui-project.xml</PROJECT>
                                 </env>
                                 <ports>
                                     <port>soap.host.port:8080</port>
@@ -373,17 +397,21 @@
                                 <log>
                                     <enabled>false</enabled>
                                 </log>
+                                <!--Workaround for avoiding name collisions with zombie containers left from failed executions-->
+                                <!--or parallel executions on same agent-->
+                                <containerNamePattern>%n-%i-%t</containerNamePattern>
                             </run>
                         </image>
                         <image>
                             <name>ws-simple-soap12</name>
                             <build>
-                                <dockerFileDir>${project.basedir}</dockerFileDir>
+                                <contextDir>${project.build.testOutputDirectory}</contextDir>
+                                <dockerFile>${project.build.testOutputDirectory}/${dockerfile}</dockerFile>
                             </build>
                             <run>
                                 <env>
                                     <MOCK_SERVICE_NAME>MUnitServiceMock</MOCK_SERVICE_NAME>
-                                    <PROJECT>/home/soapui/soapui-prj/simple-service-soap12-soapui-project.xml</PROJECT>
+                                    <PROJECT>${docker.soapui.container.project.home}simple-service-soap12-soapui-project.xml</PROJECT>
                                 </env>
                                 <ports>
                                     <port>soap12.host.port:8080</port>
@@ -391,6 +419,9 @@
                                 <log>
                                     <enabled>false</enabled>
                                 </log>
+                                <!--Workaround for avoiding name collisions with zombie containers left from failed executions-->
+                                <!--or parallel executions on same agent-->
+                                <containerNamePattern>%n-%i-%t</containerNamePattern>
                             </run>
                         </image>
                     </images>
@@ -432,5 +463,25 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>docker-windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <name>windows server 2016</name>
+                    <version>10.0</version>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <properties>
+                <dockerfile>DockerfileWindows</dockerfile>
+                <docker.soapui.container.user.home.url>file:///C:/Users/Administrator</docker.soapui.container.user.home.url>
+                <docker.soapui.container.user.home.path>C:/Users/Administrator</docker.soapui.container.user.home.path>
+                <docker.soapui.container.project.home>C:\Users\Administrator\soapui-prj\</docker.soapui.container.project.home>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/test/resources/Dockerfile
+++ b/src/test/resources/Dockerfile
@@ -1,0 +1,7 @@
+FROM fbascheper/soapui-mockservice-runner
+
+COPY soapui-prj/* /home/soapui/soapui-prj/
+COPY security/* /home/soapui/security/
+COPY wsdl/* /home/soapui/wsdl/
+
+COPY docker-libs/xmlsec-1.5.8.jar /home/soapui/SoapUI-5.4.0/lib/xmlsec-1.4.5.jar

--- a/src/test/resources/DockerfileWindows
+++ b/src/test/resources/DockerfileWindows
@@ -1,0 +1,25 @@
+# The image tag could be parameterized when needing to support multiple windows server versions
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+ENV chocolateyUseWindowsCompression false
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'));\
+    choco feature disable --name showDownloadProgress
+
+RUN choco install -y soapui --version 5.4.0
+
+EXPOSE 8080
+
+COPY .\\soapui-prj\\* C:\\Users\\Administrator\\soapui-prj/
+COPY .\\security\\* C:\\Users\\Administrator\\security/
+COPY .\\wsdl\\* C:\\Users\\Administrator\\wsdl/
+COPY [".\\\\docker-libs\\\\xmlsec-1.5.8.jar", "C:\\\\Program Files\\\\SmartBear\\\\SoapUI-5.4.0\\\\lib\\\\xmlsec-1.4.5.jar"]
+
+CMD  & 'C:\Program Files\SmartBear\SoapUI-5.4.0\bin\mockservicerunner.bat'\
+    -m $env:MOCK_SERVICE_NAME\
+    '-Djava.awt.headless=true'\
+    '-Dfile.encoding=UTF8'\
+    -p 8080\
+    $env:PROJECT

--- a/src/test/resources/soapui-prj/simple-service-soap12-soapui-project.xml
+++ b/src/test/resources/soapui-prj/simple-service-soap12-soapui-project.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<con:soapui-project id="1313c24d-4adb-43b6-a085-3949d97a8d42" activeEnvironment="Default" name="simple-service" resourceRoot="" soapui-version="5.4.0" abortOnError="false" runType="SEQUENTIAL" xmlns:con="http://eviware.com/soapui/config"><con:settings><con:setting id="ProjectSettings@hermesConfig">/Users/pangelani/.hermes</con:setting></con:settings><con:interface xsi:type="con:WsdlInterface" id="4758998d-fef0-4a35-97e9-d6b52264261a" wsaVersion="NONE" name="TestServiceSoapBinding" type="wsdl" bindingName="{http://service.soap.service.mule.org/}TestServiceSoapBinding" soapVersion="1_1" anonymous="optional" definition="file:/home/soapui/wsdl/simple-service.wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings/><con:definitionCache type="TEXT" rootPart="file:/home/soapui/wsdl/simple-service.wsdl"><con:part><con:url>file:/home/soapui/wsdl/simple-service.wsdl</con:url><con:content><![CDATA[<wsdl:definitions name="TestService" targetNamespace="http://service.soap.service.mule.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://service.soap.service.mule.org/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/">
+<con:soapui-project id="1313c24d-4adb-43b6-a085-3949d97a8d42" activeEnvironment="Default" name="simple-service" resourceRoot=""
+                    soapui-version="5.4.0" abortOnError="false" runType="SEQUENTIAL" xmlns:con="http://eviware.com/soapui/config">
+    <con:settings>
+        <con:setting id="ProjectSettings@hermesConfig">/Users/pangelani/.hermes</con:setting>
+    </con:settings>
+    <con:interface xsi:type="con:WsdlInterface" id="4758998d-fef0-4a35-97e9-d6b52264261a" wsaVersion="NONE"
+                   name="TestServiceSoapBinding" type="wsdl"
+                   bindingName="{http://service.soap.service.mule.org/}TestServiceSoapBinding" soapVersion="1_1"
+                   anonymous="optional" definition="${docker.soapui.container.user.home.url}/wsdl/simple-service.wsdl"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <con:settings/>
+        <con:definitionCache type="TEXT" rootPart="${docker.soapui.container.user.home.url}/wsdl/simple-service.wsdl">
+            <con:part>
+                <con:url>${docker.soapui.container.user.home.url}/wsdl/simple-service.wsdl</con:url>
+                <con:content><![CDATA[<wsdl:definitions name="TestService" targetNamespace="http://service.soap.service.mule.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://service.soap.service.mule.org/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/">
   <wsdl:types>
     <xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://service.soap.service.mule.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
       <xs:element name="downloadAttachment" type="tns:downloadAttachment"/>
@@ -357,19 +371,78 @@
       <soap:address location="http://localhost:1231/server"/>
     </wsdl:port>
   </wsdl:service>
-</wsdl:definitions>]]></con:content><con:type>http://schemas.xmlsoap.org/wsdl/</con:type></con:part></con:definitionCache><con:endpoints><con:endpoint>http://localhost:1231/server</con:endpoint><con:endpoint>http://localhost:8080/SOAP12</con:endpoint></con:endpoints><con:operation id="91a11ce0-c247-459f-b697-84164e60bcbd" isOneWay="false" action="downloadAttachment" name="downloadAttachment" bindingOperationName="downloadAttachment" type="Request-Response" outputName="downloadAttachmentResponse" inputName="downloadAttachment" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="bda1133b-b325-43a4-bc03-c0187c17301a" name="Request 1"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting><con:setting id="WsdlSettings@enable-mtom">false</con:setting><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@force_mtom">false</con:setting></con:settings><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:8080/SOAP12</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</wsdl:definitions>]]></con:content>
+                <con:type>http://schemas.xmlsoap.org/wsdl/</con:type>
+            </con:part>
+        </con:definitionCache>
+        <con:endpoints>
+            <con:endpoint>http://localhost:1231/server</con:endpoint>
+            <con:endpoint>http://localhost:8080/SOAP12</con:endpoint>
+        </con:endpoints>
+        <con:operation id="91a11ce0-c247-459f-b697-84164e60bcbd" isOneWay="false" action="downloadAttachment"
+                       name="downloadAttachment" bindingOperationName="downloadAttachment" type="Request-Response"
+                       outputName="downloadAttachmentResponse" inputName="downloadAttachment" receivesAttachments="false"
+                       sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="bda1133b-b325-43a4-bc03-c0187c17301a" name="Request 1">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+                    <con:setting id="WsdlSettings@enable-mtom">false</con:setting>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@force_mtom">false</con:setting>
+                </con:settings>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:8080/SOAP12</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:downloadAttachment>
          <fileName>attachment.txt</fileName>
       </ser:downloadAttachment>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="fcef34a4-8e4a-4f3c-9581-75a9f55ed39b" isOneWay="false" action="echoOperationCustomAction" name="echo" bindingOperationName="echo" type="Request-Response" outputName="echoResponse" inputName="echo" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="2b4c2164-55b5-41b9-a40f-6620b53581a7" name="Request 1"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting></con:settings><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:8080/SOAP12</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:ser="http://service.soap.service.mule.org/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="fcef34a4-8e4a-4f3c-9581-75a9f55ed39b" isOneWay="false" action="echoOperationCustomAction" name="echo"
+                       bindingOperationName="echo" type="Request-Response" outputName="echoResponse" inputName="echo"
+                       receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="2b4c2164-55b5-41b9-a40f-6620b53581a7" name="Request 1">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+                </con:settings>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:8080/SOAP12</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:ser="http://service.soap.service.mule.org/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
    <soapenv:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><xenc:EncryptedKey Id="EK-950C8F80CC5AFE6906154887610767914" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><wsse:SecurityTokenReference><ds:X509Data><ds:X509IssuerSerial><ds:X509IssuerName>CN=OLEKSIYS-W3T,OU=Sun Java System Application Server,O=Sun Microsystems,L=Santa Clara,ST=California,C=US</ds:X509IssuerName><ds:X509SerialNumber>1182300426</ds:X509SerialNumber></ds:X509IssuerSerial></ds:X509Data></wsse:SecurityTokenReference></ds:KeyInfo><xenc:CipherData><xenc:CipherValue>CLxhWibtIy0iLVZ+BJTkun0/iObDRGLu5DYmCvXyU4tEW1GY3dbOjkCIuCRTGeGS7isMLaFY/3k8FTxgymRuCPSCs57hlrrB2Ah4HKjLROymHP42tWuVRRRVG6alb3l7CsTHj+WVI3nbrJqODu3A85WXvXdXalNlLzsOze2qWZk=</xenc:CipherValue></xenc:CipherData><xenc:ReferenceList><xenc:DataReference URI="#ED-950C8F80CC5AFE6906154887610768015"/></xenc:ReferenceList></xenc:EncryptedKey></wsse:Security></soapenv:Header>
 	<soapenv:Body>
       <ser:echo><xenc:EncryptedData Id="ED-950C8F80CC5AFE6906154887610768015" Type="http://www.w3.org/2001/04/xmlenc#Content" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><wsse:SecurityTokenReference wsse11:TokenType="http://docs.oasis-open.org/wss/oasis-wss-soap-message-security-1.1#EncryptedKey" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsse11="http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd"><wsse:Reference URI="#EK-950C8F80CC5AFE6906154887610767914"/></wsse:SecurityTokenReference></ds:KeyInfo><xenc:CipherData><xenc:CipherValue>imP4qtdTlCeHGzhmj95jlfBZ7EpcLwhE8XqvvrjZC1jnjfpRXrdEg3Eyyv8UfjpuNKzHZVE9iqBTIX7jLdCUEw==</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData></ser:echo>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="750f1278-e5ee-449f-a0af-2b52fb4de74c" isOneWay="false" action="echoAccount" name="echoAccount" bindingOperationName="echoAccount" type="Request-Response" outputName="echoAccountResponse" inputName="echoAccount" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="7de28365-8d39-4087-b67b-ce55040ca8d8" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="750f1278-e5ee-449f-a0af-2b52fb4de74c" isOneWay="false" action="echoAccount" name="echoAccount"
+                       bindingOperationName="echoAccount" type="Request-Response" outputName="echoAccountResponse"
+                       inputName="echoAccount" receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="7de28365-8d39-4087-b67b-ce55040ca8d8" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoAccount>
@@ -388,7 +461,25 @@
          <name>?</name>
       </ser:echoAccount>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoAccount"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="a7717091-be77-4f71-a75d-1e544f17fe62" isOneWay="false" action="echoWithHeaders" name="echoWithHeaders" bindingOperationName="echoWithHeaders" type="Request-Response" outputName="echoWithHeadersResponse" inputName="echoWithHeaders" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="511a7aa2-54d6-4708-afdb-7e323f096c05" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoAccount"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="a7717091-be77-4f71-a75d-1e544f17fe62" isOneWay="false" action="echoWithHeaders" name="echoWithHeaders"
+                       bindingOperationName="echoWithHeaders" type="Request-Response" outputName="echoWithHeadersResponse"
+                       inputName="echoWithHeaders" receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="511a7aa2-54d6-4708-afdb-7e323f096c05" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header>
       <ser:headerInOut>?</ser:headerInOut>
       <ser:headerIn>?</ser:headerIn>
@@ -399,7 +490,21 @@
          <text>?</text>
       </ser:echoWithHeaders>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoWithHeaders"/></con:call></con:operation><con:operation id="d14edfd6-aa98-49b5-888b-b866856e9a45" isOneWay="false" action="fail" name="fail" bindingOperationName="fail" type="Request-Response" outputName="failResponse" inputName="fail" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="759cba79-bd22-4d98-8e2b-012d58056fbd" name="Request 1"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting></con:settings><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:8080/SOAP12</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoWithHeaders"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="d14edfd6-aa98-49b5-888b-b866856e9a45" isOneWay="false" action="fail" name="fail"
+                       bindingOperationName="fail" type="Request-Response" outputName="failResponse" inputName="fail"
+                       receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="759cba79-bd22-4d98-8e2b-012d58056fbd" name="Request 1">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+                </con:settings>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:8080/SOAP12</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:fail>
@@ -407,24 +512,88 @@
          <text>?</text>
       </ser:fail>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="fail"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="3e1f4c97-0d47-463c-94ae-4b65797850bb" isOneWay="false" action="large" name="large" bindingOperationName="large" type="Request-Response" outputName="largeResponse" inputName="large" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="b9317080-603b-47df-b406-17797c7e2f35" name="Request 1"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting></con:settings><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:8080/SOAP12</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="fail"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="3e1f4c97-0d47-463c-94ae-4b65797850bb" isOneWay="false" action="large" name="large"
+                       bindingOperationName="large" type="Request-Response" outputName="largeResponse" inputName="large"
+                       receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="b9317080-603b-47df-b406-17797c7e2f35" name="Request 1">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+                </con:settings>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:8080/SOAP12</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:large/>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="large"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="ba80a913-daa8-4d67-82b0-18b5d3463368" isOneWay="false" action="" name="noParams" bindingOperationName="noParams" type="Request-Response" outputName="noParamsResponse" inputName="noParams" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="f70e88e2-640e-4644-8548-e83eeae85c3c" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="large"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="ba80a913-daa8-4d67-82b0-18b5d3463368" isOneWay="false" action="" name="noParams"
+                       bindingOperationName="noParams" type="Request-Response" outputName="noParamsResponse" inputName="noParams"
+                       receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="f70e88e2-640e-4644-8548-e83eeae85c3c" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:noParams/>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:wsaConfig mustUnderstand="NONE" version="200508" action="http://service.soap.service.mule.org/Soap11Service/noParams"/></con:call></con:operation><con:operation id="b476dfb1-5404-48ab-bdfa-bee86cbd5879" isOneWay="false" action="noParamsWithHeader" name="noParamsWithHeader" bindingOperationName="noParamsWithHeader" type="Request-Response" outputName="noParamsWithHeaderResponse" inputName="noParamsWithHeader" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="355efbcb-918b-4dad-b97c-b3a395078741" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:wsaConfig mustUnderstand="NONE" version="200508"
+                               action="http://service.soap.service.mule.org/Soap11Service/noParams"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="b476dfb1-5404-48ab-bdfa-bee86cbd5879" isOneWay="false" action="noParamsWithHeader"
+                       name="noParamsWithHeader" bindingOperationName="noParamsWithHeader" type="Request-Response"
+                       outputName="noParamsWithHeaderResponse" inputName="noParamsWithHeader" receivesAttachments="false"
+                       sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="355efbcb-918b-4dad-b97c-b3a395078741" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header>
       <ser:headerIn>?</ser:headerIn>
    </soapenv:Header>
    <soapenv:Body>
       <ser:noParamsWithHeader/>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:wsaConfig mustUnderstand="NONE" version="200508" action="noParamsWithHeader"/></con:call></con:operation><con:operation id="9a991187-9db2-4229-821c-9464caf6200f" isOneWay="false" action="oneWay" name="oneWay" bindingOperationName="oneWay" type="One-Way" inputName="oneWay" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="bf350f47-9cf8-4c69-971e-cffc267e3c78" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="noParamsWithHeader"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="9a991187-9db2-4229-821c-9464caf6200f" isOneWay="false" action="oneWay" name="oneWay"
+                       bindingOperationName="oneWay" type="One-Way" inputName="oneWay" sendsAttachments="false"
+                       anonymous="optional">
+            <con:settings/>
+            <con:call id="bf350f47-9cf8-4c69-971e-cffc267e3c78" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:oneWay>
@@ -432,65 +601,218 @@
          <text>?</text>
       </ser:oneWay>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="fa8435d2-3aa6-4dae-af76-e7bb53da37a7" isOneWay="false" action="uploadAttachment" name="uploadAttachment" bindingOperationName="uploadAttachment" type="Request-Response" outputName="uploadAttachmentResponse" inputName="uploadAttachment" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="285705e6-96cd-4b52-8b6a-42059f200c7f" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="fa8435d2-3aa6-4dae-af76-e7bb53da37a7" isOneWay="false" action="uploadAttachment"
+                       name="uploadAttachment" bindingOperationName="uploadAttachment" type="Request-Response"
+                       outputName="uploadAttachmentResponse" inputName="uploadAttachment" receivesAttachments="false"
+                       sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="285705e6-96cd-4b52-8b6a-42059f200c7f" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:uploadAttachment>
          <attachment>cid:914072916446</attachment>
       </ser:uploadAttachment>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:wsaConfig mustUnderstand="NONE" version="200508" action="uploadAttachment"/></con:call></con:operation></con:interface><con:mockService id="d371dd91-d827-4a9d-aec2-672dbd285a58" port="8080" path="/SOAP12" host="localhost" name="MUnitServiceMock" bindToHostOnly="false" docroot="" incomingWss="Incoming" outgoingWss="" dispatchResponseMessages="false"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-action">false</con:setting><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-version">false</con:setting></con:settings><con:properties/><con:onRequestScript>if (mockRequest &amp;&amp; mockRequest.wssResult &amp;&amp; !mockRequest.wssResult.isEmpty()) {
-	wssResult = mockRequest.wssResult.first()
-	if (wssResult in Exception) {
-		throw wssResult;
-	}
-}</con:onRequestScript><con:afterRequestScript/><con:mockOperation name="downloadAttachment" id="e6bb63c4-f9cf-4346-af26-be44971c530d" interface="TestServiceSoapBinding" operation="downloadAttachment"><con:settings/><con:defaultResponse>Response</con:defaultResponse><con:dispatchStyle>QUERY_MATCH</con:dispatchStyle><con:dispatchPath/><con:response name="Response" id="e736de33-e7c1-46fa-8797-41eef49bffcb" httpResponseStatus="200" encoding="UTF-8"><con:settings><con:setting id="WsdlSettings@enable-mtom">false</con:setting><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@force_mtom">false</con:setting></con:settings><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="uploadAttachment"/>
+            </con:call>
+        </con:operation>
+    </con:interface>
+    <con:mockService id="d371dd91-d827-4a9d-aec2-672dbd285a58" port="8080" path="/SOAP12" host="localhost" name="MUnitServiceMock"
+                     bindToHostOnly="false" docroot="" incomingWss="Incoming" outgoingWss="" dispatchResponseMessages="false">
+        <con:settings>
+            <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-action">false</con:setting>
+            <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-version">false</con:setting>
+        </con:settings>
+        <con:properties/>
+        <con:onRequestScript>if (mockRequest &amp;&amp; mockRequest.wssResult &amp;&amp; !mockRequest.wssResult.isEmpty()) {
+            wssResult = mockRequest.wssResult.first()
+            if (wssResult in Exception) {
+            throw wssResult;
+            }
+            }
+        </con:onRequestScript>
+        <con:afterRequestScript/>
+        <con:mockOperation name="downloadAttachment" id="e6bb63c4-f9cf-4346-af26-be44971c530d" interface="TestServiceSoapBinding"
+                           operation="downloadAttachment">
+            <con:settings/>
+            <con:defaultResponse>Response</con:defaultResponse>
+            <con:dispatchStyle>QUERY_MATCH</con:dispatchStyle>
+            <con:dispatchPath/>
+            <con:response name="Response" id="e736de33-e7c1-46fa-8797-41eef49bffcb" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings>
+                    <con:setting id="WsdlSettings@enable-mtom">false</con:setting>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@force_mtom">false</con:setting>
+                </con:settings>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:downloadAttachmentResponse>
          <attachment>cid:1271018540948</attachment>
       </ser:downloadAttachmentResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:attachment><con:name>attachment.txt</con:name><con:contentType>text/plain</con:contentType><con:size>26</con:size><con:contentId>attachment.txt</con:contentId><con:part>1271018540948</con:part><con:data>UEsDBBQACAgIAG6LPE4AAAAAAAAAAAAAAAAOAAAAYXR0YWNobWVudC50eHQLzswtyElVcCwpSUzOyE3NK1Fwzs8rAdJcAFBLBwhl6Ny1GgAAABoAAABQSwECFAAUAAgICABuizxOZejctRoAAAAaAAAADgAAAAAAAAAAAAAAAAAAAAAAYXR0YWNobWVudC50eHRQSwUGAAAAAAEAAQA8AAAAVgAAAAAA</con:data><con:id>6d8b3404-5cbe-4ae3-a78c-2e2aef4fc271</con:id></con:attachment><con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/></con:response><con:response name="Response MTOM" id="e736de33-e7c1-46fa-8797-41eef49bffcb" httpResponseStatus="200" encoding="UTF-8"><con:settings><con:setting id="WsdlSettings@enable-mtom">true</con:setting><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@force_mtom">false</con:setting></con:settings><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:attachment>
+                    <con:name>attachment.txt</con:name>
+                    <con:contentType>text/plain</con:contentType>
+                    <con:size>26</con:size>
+                    <con:contentId>attachment.txt</con:contentId>
+                    <con:part>1271018540948</con:part>
+                    <con:data>
+                        UEsDBBQACAgIAG6LPE4AAAAAAAAAAAAAAAAOAAAAYXR0YWNobWVudC50eHQLzswtyElVcCwpSUzOyE3NK1Fwzs8rAdJcAFBLBwhl6Ny1GgAAABoAAABQSwECFAAUAAgICABuizxOZejctRoAAAAaAAAADgAAAAAAAAAAAAAAAAAAAAAAYXR0YWNobWVudC50eHRQSwUGAAAAAAEAAQA8AAAAVgAAAAAA
+                    </con:data>
+                    <con:id>6d8b3404-5cbe-4ae3-a78c-2e2aef4fc271</con:id>
+                </con:attachment>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/>
+            </con:response>
+            <con:response name="Response MTOM" id="e736de33-e7c1-46fa-8797-41eef49bffcb" httpResponseStatus="200"
+                          encoding="UTF-8">
+                <con:settings>
+                    <con:setting id="WsdlSettings@enable-mtom">true</con:setting>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@force_mtom">false</con:setting>
+                </con:settings>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:downloadAttachmentResponse>
          <attachment>cid:1271018540948</attachment>
       </ser:downloadAttachmentResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:attachment><con:name>attachment.txt</con:name><con:contentType>text/plain</con:contentType><con:size>26</con:size><con:contentId>attachment.txt</con:contentId><con:part>1271018540948</con:part><con:data>UEsDBBQACAgIAG6LPE4AAAAAAAAAAAAAAAAOAAAAYXR0YWNobWVudC50eHQLzswtyElVcCwpSUzOyE3NK1Fwzs8rAdJcAFBLBwhl6Ny1GgAAABoAAABQSwECFAAUAAgICABuizxOZejctRoAAAAaAAAADgAAAAAAAAAAAAAAAAAAAAAAYXR0YWNobWVudC50eHRQSwUGAAAAAAEAAQA8AAAAVgAAAAAA</con:data><con:id>6d8b3404-5cbe-4ae3-a78c-2e2aef4fc271</con:id></con:attachment><con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/></con:response><con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:query><con:name>MTOM</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:downloadAttachment/fileName</con:query><con:match>attachment.txt</con:match><con:response>Response MTOM</con:response></con:query></con:dispatchConfig></con:mockOperation><con:mockOperation name="echo" id="cb8ab6f2-8d7c-48c6-ab80-9b54f825ee12" interface="TestServiceSoapBinding" operation="echo"><con:settings/><con:defaultResponse>Response</con:defaultResponse><con:dispatchStyle>QUERY_MATCH</con:dispatchStyle><con:dispatchPath/><con:response name="Response" id="65851d7a-caa9-457c-b822-a2d3a75a5766" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:attachment>
+                    <con:name>attachment.txt</con:name>
+                    <con:contentType>text/plain</con:contentType>
+                    <con:size>26</con:size>
+                    <con:contentId>attachment.txt</con:contentId>
+                    <con:part>1271018540948</con:part>
+                    <con:data>
+                        UEsDBBQACAgIAG6LPE4AAAAAAAAAAAAAAAAOAAAAYXR0YWNobWVudC50eHQLzswtyElVcCwpSUzOyE3NK1Fwzs8rAdJcAFBLBwhl6Ny1GgAAABoAAABQSwECFAAUAAgICABuizxOZejctRoAAAAaAAAADgAAAAAAAAAAAAAAAAAAAAAAYXR0YWNobWVudC50eHRQSwUGAAAAAAEAAQA8AAAAVgAAAAAA
+                    </con:data>
+                    <con:id>6d8b3404-5cbe-4ae3-a78c-2e2aef4fc271</con:id>
+                </con:attachment>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/>
+            </con:response>
+            <con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <con:query>
+                    <con:name>MTOM</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:downloadAttachment/fileName
+                    </con:query>
+                    <con:match>attachment.txt</con:match>
+                    <con:response>Response MTOM</con:response>
+                </con:query>
+            </con:dispatchConfig>
+        </con:mockOperation>
+        <con:mockOperation name="echo" id="cb8ab6f2-8d7c-48c6-ab80-9b54f825ee12" interface="TestServiceSoapBinding"
+                           operation="echo">
+            <con:settings/>
+            <con:defaultResponse>Response</con:defaultResponse>
+            <con:dispatchStyle>QUERY_MATCH</con:dispatchStyle>
+            <con:dispatchPath/>
+            <con:response name="Response" id="65851d7a-caa9-457c-b822-a2d3a75a5766" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoResponse>
          <text>test response</text>
       </ser:echoResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/></con:response><con:response name="EncryptedResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200" encoding="UTF-8" outgoingWss="EncryptedResponse"><con:settings><con:setting id="WsdlSettings@enable-mtom">false</con:setting></con:settings><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+            </con:response>
+            <con:response name="EncryptedResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200"
+                          encoding="UTF-8" outgoingWss="EncryptedResponse">
+                <con:settings>
+                    <con:setting id="WsdlSettings@enable-mtom">false</con:setting>
+                </con:settings>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoResponse>
          <text>test response</text>
       </ser:echoResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/></con:response><con:response name="SignedResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200" encoding="UTF-8" outgoingWss="SignedResponse"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+            </con:response>
+            <con:response name="SignedResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200"
+                          encoding="UTF-8" outgoingWss="SignedResponse">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoResponse>
          <text>test response</text>
       </ser:echoResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/></con:response><con:response name="TimestampResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200" encoding="UTF-8" outgoingWss="TimestampResponse"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+            </con:response>
+            <con:response name="TimestampResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200"
+                          encoding="UTF-8" outgoingWss="TimestampResponse">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoResponse>
          <text>test response</text>
       </ser:echoResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/></con:response><con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:query><con:name>Encrypted</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:echo/text</con:query><con:match>encrypted</con:match><con:response>EncryptedResponse</con:response></con:query><con:query><con:name>Signed</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:echo/text</con:query><con:match>signed</con:match><con:response>SignedResponse</con:response></con:query><con:query><con:name>Timestamp</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:echo/text</con:query><con:match>timestamp</con:match><con:response>TimestampResponse</con:response></con:query></con:dispatchConfig></con:mockOperation><con:mockOperation name="echoAccount" id="35e23e58-03f2-4757-a859-b1ab6bfe439f" interface="TestServiceSoapBinding" operation="echoAccount"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="c8c483c8-1ea3-4bb1-b528-7db801ee09ab" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+            </con:response>
+            <con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <con:query>
+                    <con:name>Encrypted</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:echo/text
+                    </con:query>
+                    <con:match>encrypted</con:match>
+                    <con:response>EncryptedResponse</con:response>
+                </con:query>
+                <con:query>
+                    <con:name>Signed</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:echo/text
+                    </con:query>
+                    <con:match>signed</con:match>
+                    <con:response>SignedResponse</con:response>
+                </con:query>
+                <con:query>
+                    <con:name>Timestamp</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:echo/text
+                    </con:query>
+                    <con:match>timestamp</con:match>
+                    <con:response>TimestampResponse</con:response>
+                </con:query>
+            </con:dispatchConfig>
+        </con:mockOperation>
+        <con:mockOperation name="echoAccount" id="35e23e58-03f2-4757-a859-b1ab6bfe439f" interface="TestServiceSoapBinding"
+                           operation="echoAccount">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="c8c483c8-1ea3-4bb1-b528-7db801ee09ab" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoAccountResponse>
@@ -504,7 +826,19 @@
          </account>
       </ser:echoAccountResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoAccount"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="echoWithHeaders" id="073c5690-5890-4bf9-9007-cfca827f3685" interface="TestServiceSoapBinding" operation="echoWithHeaders"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="f8cee604-e596-4916-9629-a20a354db87b" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoAccount"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="echoWithHeaders" id="073c5690-5890-4bf9-9007-cfca827f3685" interface="TestServiceSoapBinding"
+                           operation="echoWithHeaders">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="f8cee604-e596-4916-9629-a20a354db87b" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header>
       <ser:headerInOut>Header In Out Value INOUT</ser:headerInOut>
       <ser:headerOut>Header In Value OUT</ser:headerOut>
@@ -514,7 +848,19 @@
          <text>test response</text>
       </ser:echoWithHeadersResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoWithHeaders"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="fail" id="b2eca3a7-6380-4808-82c8-45922bc8ea98" interface="TestServiceSoapBinding" operation="fail"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="811e081b-5593-49c0-81d7-63c591da05b3" httpResponseStatus="500" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoWithHeaders"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="fail" id="b2eca3a7-6380-4808-82c8-45922bc8ea98" interface="TestServiceSoapBinding"
+                           operation="fail">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="811e081b-5593-49c0-81d7-63c591da05b3" httpResponseStatus="500" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
    <soapenv:Body>
       <soapenv:Fault>
          <faultcode>Server</faultcode>
@@ -522,37 +868,205 @@
          <detail><text>Fail Message</text></detail>
       </soapenv:Fault>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="fail"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="large" id="062db54f-f190-4155-bf5a-4e0a64de53ec" interface="TestServiceSoapBinding" operation="large"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="96ca171c-f8e8-4944-8d96-ecfd3b085379" httpResponseStatus="200" encoding="UTF-8"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@response-delay">2000</con:setting></con:settings><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="fail"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="large" id="062db54f-f190-4155-bf5a-4e0a64de53ec" interface="TestServiceSoapBinding"
+                           operation="large">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="96ca171c-f8e8-4944-8d96-ecfd3b085379" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@response-delay">2000</con:setting>
+                </con:settings>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:largeResponse>
          <text>large</text>
       </ser:largeResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="large"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="noParams" id="4265fae8-6a3c-4f53-8864-b09ab60647fa" interface="TestServiceSoapBinding" operation="noParams"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="ece3873e-9385-42af-854b-c8ca2dce1510" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="large"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="noParams" id="4265fae8-6a3c-4f53-8864-b09ab60647fa" interface="TestServiceSoapBinding"
+                           operation="noParams">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="ece3873e-9385-42af-854b-c8ca2dce1510" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:noParamsResponse>
          <text>response</text>
       </ser:noParamsResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="http://service.soap.service.mule.org/Soap11Service/noParamsResponse"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="noParamsWithHeader" id="605aefa1-e1c0-4334-ace3-34c636ab366c" interface="TestServiceSoapBinding" operation="noParamsWithHeader"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="be6b7e9e-5e6d-4c6e-86dd-f7166dc86dd0" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508"
+                               action="http://service.soap.service.mule.org/Soap11Service/noParamsResponse"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="noParamsWithHeader" id="605aefa1-e1c0-4334-ace3-34c636ab366c" interface="TestServiceSoapBinding"
+                           operation="noParamsWithHeader">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="be6b7e9e-5e6d-4c6e-86dd-f7166dc86dd0" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:noParamsWithHeaderResponse>
          <text>Header In Value</text>
       </ser:noParamsWithHeaderResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="noParamsWithHeader"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="oneWay" id="28c453e9-44a3-42d6-bb0d-2792bc6b98b6" interface="TestServiceSoapBinding" operation="oneWay"><con:settings/><con:defaultResponse>Unauthorized</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>basic = mockRequest.requestHeaders.get('Authorization');
-if (basic.first() == 'Basic anVhbmk6Y2hhbmdlSXQ=') {
-	return 'Authorized'
-}
-return 'Unauthorized'</con:dispatchPath><con:response name="Authorized" id="66fa4168-dce0-4dec-a7fc-6f3b0fdb3a9f" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent/><con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/></con:response><con:response name="Unauthorized" id="8aa89969-70ef-4a7b-82d6-8a27c745d253" httpResponseStatus="401" encoding="UTF-8"><con:settings/><con:responseContent/><con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/></con:response><con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:query><con:name>Valid Username &amp; Password</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:downloadAttachment/fileName</con:query><con:match/><con:response>Authorized</con:response></con:query></con:dispatchConfig></con:mockOperation><con:mockOperation name="uploadAttachment" id="27613970-3d59-4ffe-b9f6-34304418f46d" interface="TestServiceSoapBinding" operation="uploadAttachment"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="9164d61c-db88-40a7-8595-f4272248c809" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="noParamsWithHeader"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="oneWay" id="28c453e9-44a3-42d6-bb0d-2792bc6b98b6" interface="TestServiceSoapBinding"
+                           operation="oneWay">
+            <con:settings/>
+            <con:defaultResponse>Unauthorized</con:defaultResponse>
+            <con:dispatchStyle>SCRIPT</con:dispatchStyle>
+            <con:dispatchPath>basic = mockRequest.requestHeaders.get('Authorization');
+                if (basic.first() == 'Basic anVhbmk6Y2hhbmdlSXQ=') {
+                return 'Authorized'
+                }
+                return 'Unauthorized'
+            </con:dispatchPath>
+            <con:response name="Authorized" id="66fa4168-dce0-4dec-a7fc-6f3b0fdb3a9f" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/>
+            </con:response>
+            <con:response name="Unauthorized" id="8aa89969-70ef-4a7b-82d6-8a27c745d253" httpResponseStatus="401" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/>
+            </con:response>
+            <con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <con:query>
+                    <con:name>Valid Username &amp; Password</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:downloadAttachment/fileName
+                    </con:query>
+                    <con:match/>
+                    <con:response>Authorized</con:response>
+                </con:query>
+            </con:dispatchConfig>
+        </con:mockOperation>
+        <con:mockOperation name="uploadAttachment" id="27613970-3d59-4ffe-b9f6-34304418f46d" interface="TestServiceSoapBinding"
+                           operation="uploadAttachment">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="9164d61c-db88-40a7-8595-f4272248c809" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:uploadAttachmentResponse>
          <result>OK</result>
       </ser:uploadAttachmentResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="uploadAttachment"/></con:response><con:dispatchConfig/></con:mockOperation></con:mockService><con:endpointStrategy xsi:type="con:DefaultEndpointStrategy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:endpoint mode="COMPLEMENT" outgoingWss="SecureResponse">http://localhost:8081</con:endpoint></con:endpointStrategy><con:properties/><con:wssContainer><con:crypto><con:source>/home/soapui/security/ssltest-keystore.jks</con:source><con:password>changeit</con:password><con:type>KEYSTORE</con:type><con:defaultAlias>s1as</con:defaultAlias><con:aliasPassword>changeit</con:aliasPassword></con:crypto><con:crypto><con:source>/home/soapui/security/trustStore</con:source><con:password>mulepassword</con:password><con:type>TRUSTSTORE</con:type></con:crypto><con:crypto><con:source>/home/soapui/security/ssltest-cacerts.jks</con:source><con:password>changeit</con:password><con:type>KEYSTORE</con:type><con:defaultAlias>s1as</con:defaultAlias><con:aliasPassword>changeit</con:aliasPassword></con:crypto><con:crypto><con:source>/home/soapui/security/serverKeystore</con:source><con:password>mulepassword</con:password><con:type>KEYSTORE</con:type></con:crypto><con:crypto><con:source>/home/soapui/security/trustStoreWithoutMuleServerCertificate</con:source><con:password>mulepassword</con:password><con:type>TRUSTSTORE</con:type></con:crypto><con:incoming><con:name>Incoming</con:name><con:decryptCrypto>ssltest-keystore.jks</con:decryptCrypto><con:signatureCrypto>trustStoreWithoutMuleServerCertificate</con:signatureCrypto><con:decryptPassword>changeit</con:decryptPassword></con:incoming><con:outgoing><con:name>EncryptedResponse</con:name><con:entry type="Encryption" username="s1as" password="changeit"><con:configuration><crypto>ssltest-keystore.jks</crypto><keyIdentifierType>2</keyIdentifierType><symmetricEncAlgorithm/><encKeyTransport/><embeddedKeyName/><embeddedKeyPassword/><encryptionCanonicalization/><encryptSymmetricKey>true</encryptSymmetricKey></con:configuration></con:entry></con:outgoing><con:outgoing><con:name>SignedResponse</con:name><con:entry type="Signature" username="muleserver" password="mulepassword"><con:configuration><crypto>serverKeystore</crypto><keyIdentifierType>2</keyIdentifierType><signatureAlgorithm/><signatureCanonicalization/><useSingleCert>false</useSingleCert><digestAlgorithm/><customTokenValueType/><customTokenId/></con:configuration></con:entry></con:outgoing><con:outgoing><con:name>TimestampResponse</con:name><con:entry type="Timestamp"><con:configuration><timeToLive>30000</timeToLive><strictTimestamp>true</strictTimestamp></con:configuration></con:entry></con:outgoing></con:wssContainer><con:oAuth2ProfileContainer/><con:oAuth1ProfileContainer/><con:sensitiveInformation/></con:soapui-project>
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="uploadAttachment"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+    </con:mockService>
+    <con:endpointStrategy xsi:type="con:DefaultEndpointStrategy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <con:endpoint mode="COMPLEMENT" outgoingWss="SecureResponse">http://localhost:8081</con:endpoint>
+    </con:endpointStrategy>
+    <con:properties/>
+    <con:wssContainer>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/ssltest-keystore.jks</con:source>
+            <con:password>changeit</con:password>
+            <con:type>KEYSTORE</con:type>
+            <con:defaultAlias>s1as</con:defaultAlias>
+            <con:aliasPassword>changeit</con:aliasPassword>
+        </con:crypto>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/trustStore</con:source>
+            <con:password>mulepassword</con:password>
+            <con:type>TRUSTSTORE</con:type>
+        </con:crypto>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/ssltest-cacerts.jks</con:source>
+            <con:password>changeit</con:password>
+            <con:type>KEYSTORE</con:type>
+            <con:defaultAlias>s1as</con:defaultAlias>
+            <con:aliasPassword>changeit</con:aliasPassword>
+        </con:crypto>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/serverKeystore</con:source>
+            <con:password>mulepassword</con:password>
+            <con:type>KEYSTORE</con:type>
+        </con:crypto>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/trustStoreWithoutMuleServerCertificate</con:source>
+            <con:password>mulepassword</con:password>
+            <con:type>TRUSTSTORE</con:type>
+        </con:crypto>
+        <con:incoming>
+            <con:name>Incoming</con:name>
+            <con:decryptCrypto>ssltest-keystore.jks</con:decryptCrypto>
+            <con:signatureCrypto>trustStoreWithoutMuleServerCertificate</con:signatureCrypto>
+            <con:decryptPassword>changeit</con:decryptPassword>
+        </con:incoming>
+        <con:outgoing>
+            <con:name>EncryptedResponse</con:name>
+            <con:entry type="Encryption" username="s1as" password="changeit">
+                <con:configuration>
+                    <crypto>ssltest-keystore.jks</crypto>
+                    <keyIdentifierType>2</keyIdentifierType>
+                    <symmetricEncAlgorithm/>
+                    <encKeyTransport/>
+                    <embeddedKeyName/>
+                    <embeddedKeyPassword/>
+                    <encryptionCanonicalization/>
+                    <encryptSymmetricKey>true</encryptSymmetricKey>
+                </con:configuration>
+            </con:entry>
+        </con:outgoing>
+        <con:outgoing>
+            <con:name>SignedResponse</con:name>
+            <con:entry type="Signature" username="muleserver" password="mulepassword">
+                <con:configuration>
+                    <crypto>serverKeystore</crypto>
+                    <keyIdentifierType>2</keyIdentifierType>
+                    <signatureAlgorithm/>
+                    <signatureCanonicalization/>
+                    <useSingleCert>false</useSingleCert>
+                    <digestAlgorithm/>
+                    <customTokenValueType/>
+                    <customTokenId/>
+                </con:configuration>
+            </con:entry>
+        </con:outgoing>
+        <con:outgoing>
+            <con:name>TimestampResponse</con:name>
+            <con:entry type="Timestamp">
+                <con:configuration>
+                    <timeToLive>30000</timeToLive>
+                    <strictTimestamp>true</strictTimestamp>
+                </con:configuration>
+            </con:entry>
+        </con:outgoing>
+    </con:wssContainer>
+    <con:oAuth2ProfileContainer/>
+    <con:oAuth1ProfileContainer/>
+    <con:sensitiveInformation/>
+</con:soapui-project>

--- a/src/test/resources/soapui-prj/simple-service-soapui-project.xml
+++ b/src/test/resources/soapui-prj/simple-service-soapui-project.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<con:soapui-project id="1313c24d-4adb-43b6-a085-3949d97a8d42" activeEnvironment="Default" name="simple-service" resourceRoot="" soapui-version="5.4.0" abortOnError="false" runType="SEQUENTIAL" xmlns:con="http://eviware.com/soapui/config"><con:settings><con:setting id="ProjectSettings@hermesConfig">/Users/pangelani/.hermes</con:setting></con:settings><con:interface xsi:type="con:WsdlInterface" id="4758998d-fef0-4a35-97e9-d6b52264261a" wsaVersion="NONE" name="TestServiceSoapBinding" type="wsdl" bindingName="{http://service.soap.service.mule.org/}TestServiceSoapBinding" soapVersion="1_1" anonymous="optional" definition="file:/home/soapui/wsdl/simple-service.wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:settings/><con:definitionCache type="TEXT" rootPart="file:/home/soapui/wsdl/simple-service.wsdl"><con:part><con:url>file:/home/soapui/wsdl/simple-service.wsdl</con:url><con:content><![CDATA[<wsdl:definitions name="TestService" targetNamespace="http://service.soap.service.mule.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://service.soap.service.mule.org/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+<con:soapui-project id="1313c24d-4adb-43b6-a085-3949d97a8d42" activeEnvironment="Default" name="simple-service" resourceRoot=""
+                    soapui-version="5.4.0" abortOnError="false" runType="SEQUENTIAL" xmlns:con="http://eviware.com/soapui/config">
+    <con:settings>
+        <con:setting id="ProjectSettings@hermesConfig">/Users/pangelani/.hermes</con:setting>
+    </con:settings>
+    <con:interface xsi:type="con:WsdlInterface" id="4758998d-fef0-4a35-97e9-d6b52264261a" wsaVersion="NONE"
+                   name="TestServiceSoapBinding" type="wsdl"
+                   bindingName="{http://service.soap.service.mule.org/}TestServiceSoapBinding" soapVersion="1_1"
+                   anonymous="optional" definition="${docker.soapui.container.user.home.url}/wsdl/simple-service.wsdl"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <con:settings/>
+        <con:definitionCache type="TEXT" rootPart="${docker.soapui.container.user.home.url}/wsdl/simple-service.wsdl">
+            <con:part>
+                <con:url>${docker.soapui.container.user.home.url}/wsdl/simple-service.wsdl</con:url>
+                <con:content><![CDATA[<wsdl:definitions name="TestService" targetNamespace="http://service.soap.service.mule.org/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://service.soap.service.mule.org/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
   <wsdl:types>
     <xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://service.soap.service.mule.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
       <xs:element name="downloadAttachment" type="tns:downloadAttachment"/>
@@ -357,19 +371,78 @@
       <soap:address location="http://localhost:1231/server"/>
     </wsdl:port>
   </wsdl:service>
-</wsdl:definitions>]]></con:content><con:type>http://schemas.xmlsoap.org/wsdl/</con:type></con:part></con:definitionCache><con:endpoints><con:endpoint>http://localhost:1231/server</con:endpoint><con:endpoint>http://localhost:8080/SOAP11</con:endpoint></con:endpoints><con:operation id="91a11ce0-c247-459f-b697-84164e60bcbd" isOneWay="false" action="downloadAttachment" name="downloadAttachment" bindingOperationName="downloadAttachment" type="Request-Response" outputName="downloadAttachmentResponse" inputName="downloadAttachment" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="bda1133b-b325-43a4-bc03-c0187c17301a" name="Request 1"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting><con:setting id="WsdlSettings@enable-mtom">false</con:setting><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@force_mtom">false</con:setting></con:settings><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:8080/SOAP11</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</wsdl:definitions>]]></con:content>
+                <con:type>http://schemas.xmlsoap.org/wsdl/</con:type>
+            </con:part>
+        </con:definitionCache>
+        <con:endpoints>
+            <con:endpoint>http://localhost:1231/server</con:endpoint>
+            <con:endpoint>http://localhost:8080/SOAP11</con:endpoint>
+        </con:endpoints>
+        <con:operation id="91a11ce0-c247-459f-b697-84164e60bcbd" isOneWay="false" action="downloadAttachment"
+                       name="downloadAttachment" bindingOperationName="downloadAttachment" type="Request-Response"
+                       outputName="downloadAttachmentResponse" inputName="downloadAttachment" receivesAttachments="false"
+                       sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="bda1133b-b325-43a4-bc03-c0187c17301a" name="Request 1">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+                    <con:setting id="WsdlSettings@enable-mtom">false</con:setting>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@force_mtom">false</con:setting>
+                </con:settings>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:8080/SOAP11</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:downloadAttachment>
          <fileName>attachment.txt</fileName>
       </ser:downloadAttachment>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="fcef34a4-8e4a-4f3c-9581-75a9f55ed39b" isOneWay="false" action="echoOperationCustomAction" name="echo" bindingOperationName="echo" type="Request-Response" outputName="echoResponse" inputName="echo" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="2b4c2164-55b5-41b9-a40f-6620b53581a7" name="Request 1"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting></con:settings><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:8080/SOAP11</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:ser="http://service.soap.service.mule.org/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="fcef34a4-8e4a-4f3c-9581-75a9f55ed39b" isOneWay="false" action="echoOperationCustomAction" name="echo"
+                       bindingOperationName="echo" type="Request-Response" outputName="echoResponse" inputName="echo"
+                       receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="2b4c2164-55b5-41b9-a40f-6620b53581a7" name="Request 1">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+                </con:settings>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:8080/SOAP11</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:ser="http://service.soap.service.mule.org/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
    <soapenv:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><xenc:EncryptedKey Id="EK-950C8F80CC5AFE6906154887610767914" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><wsse:SecurityTokenReference><ds:X509Data><ds:X509IssuerSerial><ds:X509IssuerName>CN=OLEKSIYS-W3T,OU=Sun Java System Application Server,O=Sun Microsystems,L=Santa Clara,ST=California,C=US</ds:X509IssuerName><ds:X509SerialNumber>1182300426</ds:X509SerialNumber></ds:X509IssuerSerial></ds:X509Data></wsse:SecurityTokenReference></ds:KeyInfo><xenc:CipherData><xenc:CipherValue>CLxhWibtIy0iLVZ+BJTkun0/iObDRGLu5DYmCvXyU4tEW1GY3dbOjkCIuCRTGeGS7isMLaFY/3k8FTxgymRuCPSCs57hlrrB2Ah4HKjLROymHP42tWuVRRRVG6alb3l7CsTHj+WVI3nbrJqODu3A85WXvXdXalNlLzsOze2qWZk=</xenc:CipherValue></xenc:CipherData><xenc:ReferenceList><xenc:DataReference URI="#ED-950C8F80CC5AFE6906154887610768015"/></xenc:ReferenceList></xenc:EncryptedKey></wsse:Security></soapenv:Header>
 	<soapenv:Body>
       <ser:echo><xenc:EncryptedData Id="ED-950C8F80CC5AFE6906154887610768015" Type="http://www.w3.org/2001/04/xmlenc#Content" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><wsse:SecurityTokenReference wsse11:TokenType="http://docs.oasis-open.org/wss/oasis-wss-soap-message-security-1.1#EncryptedKey" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" xmlns:wsse11="http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd"><wsse:Reference URI="#EK-950C8F80CC5AFE6906154887610767914"/></wsse:SecurityTokenReference></ds:KeyInfo><xenc:CipherData><xenc:CipherValue>imP4qtdTlCeHGzhmj95jlfBZ7EpcLwhE8XqvvrjZC1jnjfpRXrdEg3Eyyv8UfjpuNKzHZVE9iqBTIX7jLdCUEw==</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData></ser:echo>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="750f1278-e5ee-449f-a0af-2b52fb4de74c" isOneWay="false" action="echoAccount" name="echoAccount" bindingOperationName="echoAccount" type="Request-Response" outputName="echoAccountResponse" inputName="echoAccount" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="7de28365-8d39-4087-b67b-ce55040ca8d8" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="750f1278-e5ee-449f-a0af-2b52fb4de74c" isOneWay="false" action="echoAccount" name="echoAccount"
+                       bindingOperationName="echoAccount" type="Request-Response" outputName="echoAccountResponse"
+                       inputName="echoAccount" receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="7de28365-8d39-4087-b67b-ce55040ca8d8" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoAccount>
@@ -388,7 +461,25 @@
          <name>?</name>
       </ser:echoAccount>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoAccount"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="a7717091-be77-4f71-a75d-1e544f17fe62" isOneWay="false" action="echoWithHeaders" name="echoWithHeaders" bindingOperationName="echoWithHeaders" type="Request-Response" outputName="echoWithHeadersResponse" inputName="echoWithHeaders" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="511a7aa2-54d6-4708-afdb-7e323f096c05" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoAccount"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="a7717091-be77-4f71-a75d-1e544f17fe62" isOneWay="false" action="echoWithHeaders" name="echoWithHeaders"
+                       bindingOperationName="echoWithHeaders" type="Request-Response" outputName="echoWithHeadersResponse"
+                       inputName="echoWithHeaders" receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="511a7aa2-54d6-4708-afdb-7e323f096c05" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header>
       <ser:headerInOut>?</ser:headerInOut>
       <ser:headerIn>?</ser:headerIn>
@@ -399,7 +490,21 @@
          <text>?</text>
       </ser:echoWithHeaders>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoWithHeaders"/></con:call></con:operation><con:operation id="d14edfd6-aa98-49b5-888b-b866856e9a45" isOneWay="false" action="fail" name="fail" bindingOperationName="fail" type="Request-Response" outputName="failResponse" inputName="fail" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="759cba79-bd22-4d98-8e2b-012d58056fbd" name="Request 1"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting></con:settings><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:8080/SOAP11</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoWithHeaders"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="d14edfd6-aa98-49b5-888b-b866856e9a45" isOneWay="false" action="fail" name="fail"
+                       bindingOperationName="fail" type="Request-Response" outputName="failResponse" inputName="fail"
+                       receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="759cba79-bd22-4d98-8e2b-012d58056fbd" name="Request 1">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+                </con:settings>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:8080/SOAP11</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:fail>
@@ -407,24 +512,88 @@
          <text>?</text>
       </ser:fail>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="fail"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="3e1f4c97-0d47-463c-94ae-4b65797850bb" isOneWay="false" action="large" name="large" bindingOperationName="large" type="Request-Response" outputName="largeResponse" inputName="large" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="b9317080-603b-47df-b406-17797c7e2f35" name="Request 1"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting></con:settings><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:8080/SOAP11</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="fail"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="3e1f4c97-0d47-463c-94ae-4b65797850bb" isOneWay="false" action="large" name="large"
+                       bindingOperationName="large" type="Request-Response" outputName="largeResponse" inputName="large"
+                       receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="b9317080-603b-47df-b406-17797c7e2f35" name="Request 1">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.WsdlRequest@request-headers">&lt;xml-fragment/></con:setting>
+                </con:settings>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:8080/SOAP11</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:large/>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="large"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="ba80a913-daa8-4d67-82b0-18b5d3463368" isOneWay="false" action="" name="noParams" bindingOperationName="noParams" type="Request-Response" outputName="noParamsResponse" inputName="noParams" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="f70e88e2-640e-4644-8548-e83eeae85c3c" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="large"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="ba80a913-daa8-4d67-82b0-18b5d3463368" isOneWay="false" action="" name="noParams"
+                       bindingOperationName="noParams" type="Request-Response" outputName="noParamsResponse" inputName="noParams"
+                       receivesAttachments="false" sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="f70e88e2-640e-4644-8548-e83eeae85c3c" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:noParams/>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:wsaConfig mustUnderstand="NONE" version="200508" action="http://service.soap.service.mule.org/Soap11Service/noParams"/></con:call></con:operation><con:operation id="b476dfb1-5404-48ab-bdfa-bee86cbd5879" isOneWay="false" action="noParamsWithHeader" name="noParamsWithHeader" bindingOperationName="noParamsWithHeader" type="Request-Response" outputName="noParamsWithHeaderResponse" inputName="noParamsWithHeader" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="355efbcb-918b-4dad-b97c-b3a395078741" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:wsaConfig mustUnderstand="NONE" version="200508"
+                               action="http://service.soap.service.mule.org/Soap11Service/noParams"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="b476dfb1-5404-48ab-bdfa-bee86cbd5879" isOneWay="false" action="noParamsWithHeader"
+                       name="noParamsWithHeader" bindingOperationName="noParamsWithHeader" type="Request-Response"
+                       outputName="noParamsWithHeaderResponse" inputName="noParamsWithHeader" receivesAttachments="false"
+                       sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="355efbcb-918b-4dad-b97c-b3a395078741" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header>
       <ser:headerIn>?</ser:headerIn>
    </soapenv:Header>
    <soapenv:Body>
       <ser:noParamsWithHeader/>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:wsaConfig mustUnderstand="NONE" version="200508" action="noParamsWithHeader"/></con:call></con:operation><con:operation id="9a991187-9db2-4229-821c-9464caf6200f" isOneWay="false" action="oneWay" name="oneWay" bindingOperationName="oneWay" type="One-Way" inputName="oneWay" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="bf350f47-9cf8-4c69-971e-cffc267e3c78" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="noParamsWithHeader"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="9a991187-9db2-4229-821c-9464caf6200f" isOneWay="false" action="oneWay" name="oneWay"
+                       bindingOperationName="oneWay" type="One-Way" inputName="oneWay" sendsAttachments="false"
+                       anonymous="optional">
+            <con:settings/>
+            <con:call id="bf350f47-9cf8-4c69-971e-cffc267e3c78" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:oneWay>
@@ -432,65 +601,218 @@
          <text>?</text>
       </ser:oneWay>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:credentials><con:authType>No Authorization</con:authType></con:credentials><con:jmsConfig JMSDeliveryMode="PERSISTENT"/><con:jmsPropertyConfig/><con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/><con:wsrmConfig version="1.2"/></con:call></con:operation><con:operation id="fa8435d2-3aa6-4dae-af76-e7bb53da37a7" isOneWay="false" action="uploadAttachment" name="uploadAttachment" bindingOperationName="uploadAttachment" type="Request-Response" outputName="uploadAttachmentResponse" inputName="uploadAttachment" receivesAttachments="false" sendsAttachments="false" anonymous="optional"><con:settings/><con:call id="285705e6-96cd-4b52-8b6a-42059f200c7f" name="Request 1"><con:settings/><con:encoding>UTF-8</con:encoding><con:endpoint>http://localhost:1231/server</con:endpoint><con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:credentials>
+                    <con:authType>No Authorization</con:authType>
+                </con:credentials>
+                <con:jmsConfig JMSDeliveryMode="PERSISTENT"/>
+                <con:jmsPropertyConfig/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/>
+                <con:wsrmConfig version="1.2"/>
+            </con:call>
+        </con:operation>
+        <con:operation id="fa8435d2-3aa6-4dae-af76-e7bb53da37a7" isOneWay="false" action="uploadAttachment"
+                       name="uploadAttachment" bindingOperationName="uploadAttachment" type="Request-Response"
+                       outputName="uploadAttachmentResponse" inputName="uploadAttachment" receivesAttachments="false"
+                       sendsAttachments="false" anonymous="optional">
+            <con:settings/>
+            <con:call id="285705e6-96cd-4b52-8b6a-42059f200c7f" name="Request 1">
+                <con:settings/>
+                <con:encoding>UTF-8</con:encoding>
+                <con:endpoint>http://localhost:1231/server</con:endpoint>
+                <con:request><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:uploadAttachment>
          <attachment>cid:914072916446</attachment>
       </ser:uploadAttachment>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:request><con:wsaConfig mustUnderstand="NONE" version="200508" action="uploadAttachment"/></con:call></con:operation></con:interface><con:mockService id="d371dd91-d827-4a9d-aec2-672dbd285a58" port="8080" path="/SOAP11" host="localhost" name="MUnitServiceMock" bindToHostOnly="false" docroot="" incomingWss="Incoming" outgoingWss="" dispatchResponseMessages="false"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-action">false</con:setting><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-version">false</con:setting></con:settings><con:properties/><con:onRequestScript>if (mockRequest &amp;&amp; mockRequest.wssResult &amp;&amp; !mockRequest.wssResult.isEmpty()) {
-	wssResult = mockRequest.wssResult.first()
-	if (wssResult in Exception) {
-		throw wssResult;
-	}
-}</con:onRequestScript><con:afterRequestScript/><con:mockOperation name="downloadAttachment" id="e6bb63c4-f9cf-4346-af26-be44971c530d" interface="TestServiceSoapBinding" operation="downloadAttachment"><con:settings/><con:defaultResponse>Response</con:defaultResponse><con:dispatchStyle>QUERY_MATCH</con:dispatchStyle><con:dispatchPath/><con:response name="Response" id="e736de33-e7c1-46fa-8797-41eef49bffcb" httpResponseStatus="200" encoding="UTF-8"><con:settings><con:setting id="WsdlSettings@enable-mtom">false</con:setting><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@force_mtom">false</con:setting></con:settings><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:request>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="uploadAttachment"/>
+            </con:call>
+        </con:operation>
+    </con:interface>
+    <con:mockService id="d371dd91-d827-4a9d-aec2-672dbd285a58" port="8080" path="/SOAP11" host="localhost" name="MUnitServiceMock"
+                     bindToHostOnly="false" docroot="" incomingWss="Incoming" outgoingWss="" dispatchResponseMessages="false">
+        <con:settings>
+            <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-action">false</con:setting>
+            <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockService@require-soap-version">false</con:setting>
+        </con:settings>
+        <con:properties/>
+        <con:onRequestScript>if (mockRequest &amp;&amp; mockRequest.wssResult &amp;&amp; !mockRequest.wssResult.isEmpty()) {
+            wssResult = mockRequest.wssResult.first()
+            if (wssResult in Exception) {
+            throw wssResult;
+            }
+            }
+        </con:onRequestScript>
+        <con:afterRequestScript/>
+        <con:mockOperation name="downloadAttachment" id="e6bb63c4-f9cf-4346-af26-be44971c530d" interface="TestServiceSoapBinding"
+                           operation="downloadAttachment">
+            <con:settings/>
+            <con:defaultResponse>Response</con:defaultResponse>
+            <con:dispatchStyle>QUERY_MATCH</con:dispatchStyle>
+            <con:dispatchPath/>
+            <con:response name="Response" id="e736de33-e7c1-46fa-8797-41eef49bffcb" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings>
+                    <con:setting id="WsdlSettings@enable-mtom">false</con:setting>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@force_mtom">false</con:setting>
+                </con:settings>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:downloadAttachmentResponse>
          <attachment>cid:1271018540948</attachment>
       </ser:downloadAttachmentResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:attachment><con:name>attachment.txt</con:name><con:contentType>text/plain</con:contentType><con:size>26</con:size><con:contentId>attachment.txt</con:contentId><con:part>1271018540948</con:part><con:data>UEsDBBQACAgIAG6LPE4AAAAAAAAAAAAAAAAOAAAAYXR0YWNobWVudC50eHQLzswtyElVcCwpSUzOyE3NK1Fwzs8rAdJcAFBLBwhl6Ny1GgAAABoAAABQSwECFAAUAAgICABuizxOZejctRoAAAAaAAAADgAAAAAAAAAAAAAAAAAAAAAAYXR0YWNobWVudC50eHRQSwUGAAAAAAEAAQA8AAAAVgAAAAAA</con:data><con:id>6d8b3404-5cbe-4ae3-a78c-2e2aef4fc271</con:id></con:attachment><con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/></con:response><con:response name="Response MTOM" id="e736de33-e7c1-46fa-8797-41eef49bffcb" httpResponseStatus="200" encoding="UTF-8"><con:settings><con:setting id="WsdlSettings@enable-mtom">true</con:setting><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@force_mtom">false</con:setting></con:settings><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:attachment>
+                    <con:name>attachment.txt</con:name>
+                    <con:contentType>text/plain</con:contentType>
+                    <con:size>26</con:size>
+                    <con:contentId>attachment.txt</con:contentId>
+                    <con:part>1271018540948</con:part>
+                    <con:data>
+                        UEsDBBQACAgIAG6LPE4AAAAAAAAAAAAAAAAOAAAAYXR0YWNobWVudC50eHQLzswtyElVcCwpSUzOyE3NK1Fwzs8rAdJcAFBLBwhl6Ny1GgAAABoAAABQSwECFAAUAAgICABuizxOZejctRoAAAAaAAAADgAAAAAAAAAAAAAAAAAAAAAAYXR0YWNobWVudC50eHRQSwUGAAAAAAEAAQA8AAAAVgAAAAAA
+                    </con:data>
+                    <con:id>6d8b3404-5cbe-4ae3-a78c-2e2aef4fc271</con:id>
+                </con:attachment>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/>
+            </con:response>
+            <con:response name="Response MTOM" id="e736de33-e7c1-46fa-8797-41eef49bffcb" httpResponseStatus="200"
+                          encoding="UTF-8">
+                <con:settings>
+                    <con:setting id="WsdlSettings@enable-mtom">true</con:setting>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@force_mtom">false</con:setting>
+                </con:settings>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:downloadAttachmentResponse>
          <attachment>cid:1271018540948</attachment>
       </ser:downloadAttachmentResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:attachment><con:name>attachment.txt</con:name><con:contentType>text/plain</con:contentType><con:size>26</con:size><con:contentId>attachment.txt</con:contentId><con:part>1271018540948</con:part><con:data>UEsDBBQACAgIAG6LPE4AAAAAAAAAAAAAAAAOAAAAYXR0YWNobWVudC50eHQLzswtyElVcCwpSUzOyE3NK1Fwzs8rAdJcAFBLBwhl6Ny1GgAAABoAAABQSwECFAAUAAgICABuizxOZejctRoAAAAaAAAADgAAAAAAAAAAAAAAAAAAAAAAYXR0YWNobWVudC50eHRQSwUGAAAAAAEAAQA8AAAAVgAAAAAA</con:data><con:id>6d8b3404-5cbe-4ae3-a78c-2e2aef4fc271</con:id></con:attachment><con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/></con:response><con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:query><con:name>MTOM</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:downloadAttachment/fileName</con:query><con:match>attachment.txt</con:match><con:response>Response MTOM</con:response></con:query></con:dispatchConfig></con:mockOperation><con:mockOperation name="echo" id="cb8ab6f2-8d7c-48c6-ab80-9b54f825ee12" interface="TestServiceSoapBinding" operation="echo"><con:settings/><con:defaultResponse>Response</con:defaultResponse><con:dispatchStyle>QUERY_MATCH</con:dispatchStyle><con:dispatchPath/><con:response name="Response" id="65851d7a-caa9-457c-b822-a2d3a75a5766" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:attachment>
+                    <con:name>attachment.txt</con:name>
+                    <con:contentType>text/plain</con:contentType>
+                    <con:size>26</con:size>
+                    <con:contentId>attachment.txt</con:contentId>
+                    <con:part>1271018540948</con:part>
+                    <con:data>
+                        UEsDBBQACAgIAG6LPE4AAAAAAAAAAAAAAAAOAAAAYXR0YWNobWVudC50eHQLzswtyElVcCwpSUzOyE3NK1Fwzs8rAdJcAFBLBwhl6Ny1GgAAABoAAABQSwECFAAUAAgICABuizxOZejctRoAAAAaAAAADgAAAAAAAAAAAAAAAAAAAAAAYXR0YWNobWVudC50eHRQSwUGAAAAAAEAAQA8AAAAVgAAAAAA
+                    </con:data>
+                    <con:id>6d8b3404-5cbe-4ae3-a78c-2e2aef4fc271</con:id>
+                </con:attachment>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="downloadAttachment"/>
+            </con:response>
+            <con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <con:query>
+                    <con:name>MTOM</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:downloadAttachment/fileName
+                    </con:query>
+                    <con:match>attachment.txt</con:match>
+                    <con:response>Response MTOM</con:response>
+                </con:query>
+            </con:dispatchConfig>
+        </con:mockOperation>
+        <con:mockOperation name="echo" id="cb8ab6f2-8d7c-48c6-ab80-9b54f825ee12" interface="TestServiceSoapBinding"
+                           operation="echo">
+            <con:settings/>
+            <con:defaultResponse>Response</con:defaultResponse>
+            <con:dispatchStyle>QUERY_MATCH</con:dispatchStyle>
+            <con:dispatchPath/>
+            <con:response name="Response" id="65851d7a-caa9-457c-b822-a2d3a75a5766" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoResponse>
          <text>test response</text>
       </ser:echoResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/></con:response><con:response name="EncryptedResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200" encoding="UTF-8" outgoingWss="EncryptedResponse"><con:settings><con:setting id="WsdlSettings@enable-mtom">false</con:setting></con:settings><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+            </con:response>
+            <con:response name="EncryptedResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200"
+                          encoding="UTF-8" outgoingWss="EncryptedResponse">
+                <con:settings>
+                    <con:setting id="WsdlSettings@enable-mtom">false</con:setting>
+                </con:settings>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoResponse>
          <text>test response</text>
       </ser:echoResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/></con:response><con:response name="SignedResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200" encoding="UTF-8" outgoingWss="SignedResponse"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+            </con:response>
+            <con:response name="SignedResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200"
+                          encoding="UTF-8" outgoingWss="SignedResponse">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoResponse>
          <text>test response</text>
       </ser:echoResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/></con:response><con:response name="TimestampResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200" encoding="UTF-8" outgoingWss="TimestampResponse"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+            </con:response>
+            <con:response name="TimestampResponse" id="0ec8e2ab-d1bb-4a3e-8d7c-f02053e1536c" httpResponseStatus="200"
+                          encoding="UTF-8" outgoingWss="TimestampResponse">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoResponse>
          <text>test response</text>
       </ser:echoResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/></con:response><con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:query><con:name>Encrypted</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:echo/text</con:query><con:match>encrypted</con:match><con:response>EncryptedResponse</con:response></con:query><con:query><con:name>Signed</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:echo/text</con:query><con:match>signed</con:match><con:response>SignedResponse</con:response></con:query><con:query><con:name>Timestamp</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:echo/text</con:query><con:match>timestamp</con:match><con:response>TimestampResponse</con:response></con:query></con:dispatchConfig></con:mockOperation><con:mockOperation name="echoAccount" id="35e23e58-03f2-4757-a859-b1ab6bfe439f" interface="TestServiceSoapBinding" operation="echoAccount"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="c8c483c8-1ea3-4bb1-b528-7db801ee09ab" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoOperationCustomAction"/>
+            </con:response>
+            <con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <con:query>
+                    <con:name>Encrypted</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:echo/text
+                    </con:query>
+                    <con:match>encrypted</con:match>
+                    <con:response>EncryptedResponse</con:response>
+                </con:query>
+                <con:query>
+                    <con:name>Signed</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:echo/text
+                    </con:query>
+                    <con:match>signed</con:match>
+                    <con:response>SignedResponse</con:response>
+                </con:query>
+                <con:query>
+                    <con:name>Timestamp</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:echo/text
+                    </con:query>
+                    <con:match>timestamp</con:match>
+                    <con:response>TimestampResponse</con:response>
+                </con:query>
+            </con:dispatchConfig>
+        </con:mockOperation>
+        <con:mockOperation name="echoAccount" id="35e23e58-03f2-4757-a859-b1ab6bfe439f" interface="TestServiceSoapBinding"
+                           operation="echoAccount">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="c8c483c8-1ea3-4bb1-b528-7db801ee09ab" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:echoAccountResponse>
@@ -504,7 +826,19 @@
          </account>
       </ser:echoAccountResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoAccount"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="echoWithHeaders" id="073c5690-5890-4bf9-9007-cfca827f3685" interface="TestServiceSoapBinding" operation="echoWithHeaders"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="f8cee604-e596-4916-9629-a20a354db87b" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoAccount"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="echoWithHeaders" id="073c5690-5890-4bf9-9007-cfca827f3685" interface="TestServiceSoapBinding"
+                           operation="echoWithHeaders">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="f8cee604-e596-4916-9629-a20a354db87b" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header>
       <ser:headerInOut>Header In Out Value INOUT</ser:headerInOut>
       <ser:headerOut>Header In Value OUT</ser:headerOut>
@@ -514,7 +848,19 @@
          <text>test response</text>
       </ser:echoWithHeadersResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="echoWithHeaders"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="fail" id="b2eca3a7-6380-4808-82c8-45922bc8ea98" interface="TestServiceSoapBinding" operation="fail"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="811e081b-5593-49c0-81d7-63c591da05b3" httpResponseStatus="500" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="echoWithHeaders"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="fail" id="b2eca3a7-6380-4808-82c8-45922bc8ea98" interface="TestServiceSoapBinding"
+                           operation="fail">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="811e081b-5593-49c0-81d7-63c591da05b3" httpResponseStatus="500" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
    <soapenv:Body>
       <soapenv:Fault>
          <faultcode>Server</faultcode>
@@ -522,37 +868,205 @@
          <detail><text>Fail Message</text></detail>
       </soapenv:Fault>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="fail"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="large" id="062db54f-f190-4155-bf5a-4e0a64de53ec" interface="TestServiceSoapBinding" operation="large"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="96ca171c-f8e8-4944-8d96-ecfd3b085379" httpResponseStatus="200" encoding="UTF-8"><con:settings><con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@response-delay">2000</con:setting></con:settings><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="fail"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="large" id="062db54f-f190-4155-bf5a-4e0a64de53ec" interface="TestServiceSoapBinding"
+                           operation="large">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="96ca171c-f8e8-4944-8d96-ecfd3b085379" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings>
+                    <con:setting id="com.eviware.soapui.impl.wsdl.mock.WsdlMockResponse@response-delay">2000</con:setting>
+                </con:settings>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:largeResponse>
          <text>large</text>
       </ser:largeResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="large"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="noParams" id="4265fae8-6a3c-4f53-8864-b09ab60647fa" interface="TestServiceSoapBinding" operation="noParams"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="ece3873e-9385-42af-854b-c8ca2dce1510" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="large"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="noParams" id="4265fae8-6a3c-4f53-8864-b09ab60647fa" interface="TestServiceSoapBinding"
+                           operation="noParams">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="ece3873e-9385-42af-854b-c8ca2dce1510" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:noParamsResponse>
          <text>response</text>
       </ser:noParamsResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="http://service.soap.service.mule.org/Soap11Service/noParamsResponse"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="noParamsWithHeader" id="605aefa1-e1c0-4334-ace3-34c636ab366c" interface="TestServiceSoapBinding" operation="noParamsWithHeader"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="be6b7e9e-5e6d-4c6e-86dd-f7166dc86dd0" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508"
+                               action="http://service.soap.service.mule.org/Soap11Service/noParamsResponse"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="noParamsWithHeader" id="605aefa1-e1c0-4334-ace3-34c636ab366c" interface="TestServiceSoapBinding"
+                           operation="noParamsWithHeader">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="be6b7e9e-5e6d-4c6e-86dd-f7166dc86dd0" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:noParamsWithHeaderResponse>
          <text>Header In Value</text>
       </ser:noParamsWithHeaderResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="noParamsWithHeader"/></con:response><con:dispatchConfig/></con:mockOperation><con:mockOperation name="oneWay" id="28c453e9-44a3-42d6-bb0d-2792bc6b98b6" interface="TestServiceSoapBinding" operation="oneWay"><con:settings/><con:defaultResponse>Unauthorized</con:defaultResponse><con:dispatchStyle>SCRIPT</con:dispatchStyle><con:dispatchPath>basic = mockRequest.requestHeaders.get('Authorization');
-if (basic.first() == 'Basic anVhbmk6Y2hhbmdlSXQ=') {
-	return 'Authorized'
-}
-return 'Unauthorized'</con:dispatchPath><con:response name="Authorized" id="66fa4168-dce0-4dec-a7fc-6f3b0fdb3a9f" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent/><con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/></con:response><con:response name="Unauthorized" id="8aa89969-70ef-4a7b-82d6-8a27c745d253" httpResponseStatus="401" encoding="UTF-8"><con:settings/><con:responseContent/><con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/></con:response><con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:query><con:name>Valid Username &amp; Password</con:name><con:query>declare namespace con='http://service.soap.service.mule.org/'
-//con:downloadAttachment/fileName</con:query><con:match/><con:response>Authorized</con:response></con:query></con:dispatchConfig></con:mockOperation><con:mockOperation name="uploadAttachment" id="27613970-3d59-4ffe-b9f6-34304418f46d" interface="TestServiceSoapBinding" operation="uploadAttachment"><con:settings/><con:defaultResponse>Response 1</con:defaultResponse><con:dispatchStyle>SEQUENCE</con:dispatchStyle><con:response name="Response 1" id="9164d61c-db88-40a7-8595-f4272248c809" httpResponseStatus="200" encoding="UTF-8"><con:settings/><con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="noParamsWithHeader"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+        <con:mockOperation name="oneWay" id="28c453e9-44a3-42d6-bb0d-2792bc6b98b6" interface="TestServiceSoapBinding"
+                           operation="oneWay">
+            <con:settings/>
+            <con:defaultResponse>Unauthorized</con:defaultResponse>
+            <con:dispatchStyle>SCRIPT</con:dispatchStyle>
+            <con:dispatchPath>basic = mockRequest.requestHeaders.get('Authorization');
+                if (basic.first() == 'Basic anVhbmk6Y2hhbmdlSXQ=') {
+                return 'Authorized'
+                }
+                return 'Unauthorized'
+            </con:dispatchPath>
+            <con:response name="Authorized" id="66fa4168-dce0-4dec-a7fc-6f3b0fdb3a9f" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/>
+            </con:response>
+            <con:response name="Unauthorized" id="8aa89969-70ef-4a7b-82d6-8a27c745d253" httpResponseStatus="401" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent/>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="oneWay"/>
+            </con:response>
+            <con:dispatchConfig xsi:type="con:MockOperationQueryMatchDispatch"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <con:query>
+                    <con:name>Valid Username &amp; Password</con:name>
+                    <con:query>declare namespace con='http://service.soap.service.mule.org/'
+                        //con:downloadAttachment/fileName
+                    </con:query>
+                    <con:match/>
+                    <con:response>Authorized</con:response>
+                </con:query>
+            </con:dispatchConfig>
+        </con:mockOperation>
+        <con:mockOperation name="uploadAttachment" id="27613970-3d59-4ffe-b9f6-34304418f46d" interface="TestServiceSoapBinding"
+                           operation="uploadAttachment">
+            <con:settings/>
+            <con:defaultResponse>Response 1</con:defaultResponse>
+            <con:dispatchStyle>SEQUENCE</con:dispatchStyle>
+            <con:response name="Response 1" id="9164d61c-db88-40a7-8595-f4272248c809" httpResponseStatus="200" encoding="UTF-8">
+                <con:settings/>
+                <con:responseContent><![CDATA[<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ser="http://service.soap.service.mule.org/">
    <soapenv:Header/>
    <soapenv:Body>
       <ser:uploadAttachmentResponse>
          <result>OK</result>
       </ser:uploadAttachmentResponse>
    </soapenv:Body>
-</soapenv:Envelope>]]></con:responseContent><con:wsaConfig mustUnderstand="NONE" version="200508" action="uploadAttachment"/></con:response><con:dispatchConfig/></con:mockOperation></con:mockService><con:endpointStrategy xsi:type="con:DefaultEndpointStrategy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><con:endpoint mode="COMPLEMENT" outgoingWss="SecureResponse">http://localhost:8081</con:endpoint></con:endpointStrategy><con:properties/><con:wssContainer><con:crypto><con:source>/home/soapui/security/ssltest-keystore.jks</con:source><con:password>changeit</con:password><con:type>KEYSTORE</con:type><con:defaultAlias>s1as</con:defaultAlias><con:aliasPassword>changeit</con:aliasPassword></con:crypto><con:crypto><con:source>/home/soapui/security/trustStore</con:source><con:password>mulepassword</con:password><con:type>TRUSTSTORE</con:type></con:crypto><con:crypto><con:source>/home/soapui/security/ssltest-cacerts.jks</con:source><con:password>changeit</con:password><con:type>KEYSTORE</con:type><con:defaultAlias>s1as</con:defaultAlias><con:aliasPassword>changeit</con:aliasPassword></con:crypto><con:crypto><con:source>/home/soapui/security/serverKeystore</con:source><con:password>mulepassword</con:password><con:type>KEYSTORE</con:type></con:crypto><con:crypto><con:source>/home/soapui/security/trustStoreWithoutMuleServerCertificate</con:source><con:password>mulepassword</con:password><con:type>TRUSTSTORE</con:type></con:crypto><con:incoming><con:name>Incoming</con:name><con:decryptCrypto>ssltest-keystore.jks</con:decryptCrypto><con:signatureCrypto>trustStoreWithoutMuleServerCertificate</con:signatureCrypto><con:decryptPassword>changeit</con:decryptPassword></con:incoming><con:outgoing><con:name>EncryptedResponse</con:name><con:entry type="Encryption" username="s1as" password="changeit"><con:configuration><crypto>ssltest-keystore.jks</crypto><keyIdentifierType>2</keyIdentifierType><symmetricEncAlgorithm/><encKeyTransport/><embeddedKeyName/><embeddedKeyPassword/><encryptionCanonicalization/><encryptSymmetricKey>true</encryptSymmetricKey></con:configuration></con:entry></con:outgoing><con:outgoing><con:name>SignedResponse</con:name><con:entry type="Signature" username="muleserver" password="mulepassword"><con:configuration><crypto>serverKeystore</crypto><keyIdentifierType>2</keyIdentifierType><signatureAlgorithm/><signatureCanonicalization/><useSingleCert>false</useSingleCert><digestAlgorithm/><customTokenValueType/><customTokenId/></con:configuration></con:entry></con:outgoing><con:outgoing><con:name>TimestampResponse</con:name><con:entry type="Timestamp"><con:configuration><timeToLive>30000</timeToLive><strictTimestamp>true</strictTimestamp></con:configuration></con:entry></con:outgoing></con:wssContainer><con:oAuth2ProfileContainer/><con:oAuth1ProfileContainer/><con:sensitiveInformation/></con:soapui-project>
+</soapenv:Envelope>]]></con:responseContent>
+                <con:wsaConfig mustUnderstand="NONE" version="200508" action="uploadAttachment"/>
+            </con:response>
+            <con:dispatchConfig/>
+        </con:mockOperation>
+    </con:mockService>
+    <con:endpointStrategy xsi:type="con:DefaultEndpointStrategy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <con:endpoint mode="COMPLEMENT" outgoingWss="SecureResponse">http://localhost:8081</con:endpoint>
+    </con:endpointStrategy>
+    <con:properties/>
+    <con:wssContainer>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/ssltest-keystore.jks</con:source>
+            <con:password>changeit</con:password>
+            <con:type>KEYSTORE</con:type>
+            <con:defaultAlias>s1as</con:defaultAlias>
+            <con:aliasPassword>changeit</con:aliasPassword>
+        </con:crypto>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/trustStore</con:source>
+            <con:password>mulepassword</con:password>
+            <con:type>TRUSTSTORE</con:type>
+        </con:crypto>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/ssltest-cacerts.jks</con:source>
+            <con:password>changeit</con:password>
+            <con:type>KEYSTORE</con:type>
+            <con:defaultAlias>s1as</con:defaultAlias>
+            <con:aliasPassword>changeit</con:aliasPassword>
+        </con:crypto>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/serverKeystore</con:source>
+            <con:password>mulepassword</con:password>
+            <con:type>KEYSTORE</con:type>
+        </con:crypto>
+        <con:crypto>
+            <con:source>${docker.soapui.container.user.home.path}/security/trustStoreWithoutMuleServerCertificate</con:source>
+            <con:password>mulepassword</con:password>
+            <con:type>TRUSTSTORE</con:type>
+        </con:crypto>
+        <con:incoming>
+            <con:name>Incoming</con:name>
+            <con:decryptCrypto>ssltest-keystore.jks</con:decryptCrypto>
+            <con:signatureCrypto>trustStoreWithoutMuleServerCertificate</con:signatureCrypto>
+            <con:decryptPassword>changeit</con:decryptPassword>
+        </con:incoming>
+        <con:outgoing>
+            <con:name>EncryptedResponse</con:name>
+            <con:entry type="Encryption" username="s1as" password="changeit">
+                <con:configuration>
+                    <crypto>ssltest-keystore.jks</crypto>
+                    <keyIdentifierType>2</keyIdentifierType>
+                    <symmetricEncAlgorithm/>
+                    <encKeyTransport/>
+                    <embeddedKeyName/>
+                    <embeddedKeyPassword/>
+                    <encryptionCanonicalization/>
+                    <encryptSymmetricKey>true</encryptSymmetricKey>
+                </con:configuration>
+            </con:entry>
+        </con:outgoing>
+        <con:outgoing>
+            <con:name>SignedResponse</con:name>
+            <con:entry type="Signature" username="muleserver" password="mulepassword">
+                <con:configuration>
+                    <crypto>serverKeystore</crypto>
+                    <keyIdentifierType>2</keyIdentifierType>
+                    <signatureAlgorithm/>
+                    <signatureCanonicalization/>
+                    <useSingleCert>false</useSingleCert>
+                    <digestAlgorithm/>
+                    <customTokenValueType/>
+                    <customTokenId/>
+                </con:configuration>
+            </con:entry>
+        </con:outgoing>
+        <con:outgoing>
+            <con:name>TimestampResponse</con:name>
+            <con:entry type="Timestamp">
+                <con:configuration>
+                    <timeToLive>30000</timeToLive>
+                    <strictTimestamp>true</strictTimestamp>
+                </con:configuration>
+            </con:entry>
+        </con:outgoing>
+    </con:wssContainer>
+    <con:oAuth2ProfileContainer/>
+    <con:oAuth1ProfileContainer/>
+    <con:sensitiveInformation/>
+</con:soapui-project>


### PR DESCRIPTION
- Adding a new Dockerfile for a windows base image of the SoapUI mock
 service
 - Adjustments for allowing both images coexist and be used based on the
 OS