### PR TITLE
MULE-16931: update wsdl parser and soap engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <cxf.version>3.2.1</cxf.version>
 
         <mule.http.connector.version>1.2.0</mule.http.connector.version>
-        <soap.engine.version>1.1.2-SNAPSHOT</soap.engine.version>
-        <wsdl.parser.version>1.4.0-SNAPSHOT</wsdl.parser.version>
+        <soap.engine.version>1.1.2</soap.engine.version>
+        <wsdl.parser.version>1.3.0</wsdl.parser.version>
 
         <javax.activation.version>1.1.1</javax.activation.version>
         <javax.jaxws-api.version>2.3.0</javax.jaxws-api.version>


### PR DESCRIPTION
If merged, this commit updates the soap engine version from 1.1.2-SNAPSHOT to
1.1.2 and updates the wsdl parser version from 1.4.0-SNAPSHOT to 1.3.0