### PR TITLE
Update wsdl parser and soap engine versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <cxf.version>3.2.1</cxf.version>
 
         <mule.http.connector.version>1.5.6</mule.http.connector.version>
-        <soap.engine.version>1.2.1-SNAPSHOT</soap.engine.version>
-        <wsdl.parser.version>1.3.0</wsdl.parser.version>
+        <soap.engine.version>1.3.0-SNAPSHOT</soap.engine.version>
+        <wsdl.parser.version>1.3.2-SNAPSHOT</wsdl.parser.version>
         <javax.activation.version>1.1.1</javax.activation.version>
         <javax.jaxws-api.version>2.3.0</javax.jaxws-api.version>
         <javax.jws-api.version>1.1</javax.jws-api.version>


### PR DESCRIPTION
If merged, this commit updates wsdl parser from 1.3.0 to 1.3.1 and
soap engine from 1.2.1-SNAPSHOT to 1.2.1