### PR TITLE
MULE-17222: avoid ghosbuster to close Stream

### DIFF
--- a/src/main/java/org/mule/extension/ws/internal/transport/CursorStreamWithProvider.java
+++ b/src/main/java/org/mule/extension/ws/internal/transport/CursorStreamWithProvider.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+
+package org.mule.extension.ws.internal.transport;
+
+import org.mule.runtime.api.streaming.CursorProvider;
+import org.mule.runtime.api.streaming.bytes.CursorStream;
+import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
+import org.mule.runtime.core.internal.streaming.bytes.InputStreamBuffer;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@link CursorStream} that delegates to a {@link CursorStream} delegate and maintains a reference of the delegate to
+ * its {@link CursorStreamProvider}.
+ * <p>
+ * The purpose of this class is to avoid the runtime to close the {@link CursorStream} before it is consumed. We achieve
+ * this maintaining a hard reference of the {@link CursorStream} delegate to its {@link CursorStreamProvider}.
+ *
+ * @since 1.4.2
+ */
+public class CursorStreamWithProvider extends CursorStream {
+
+  private CursorStream cursorStreamDelegate;
+  private CursorStreamProvider cursorStreamDelegateProvider;
+
+  public CursorStreamWithProvider(CursorStream cursorStreamDelegate, CursorStreamProvider cursorStreamDelegateProvider) {
+    this.cursorStreamDelegate = cursorStreamDelegate;
+    this.cursorStreamDelegateProvider = cursorStreamDelegateProvider;
+  }
+
+  @Override
+  public int read(@NotNull byte[] b) throws IOException {
+    return cursorStreamDelegate.read(b);
+  }
+
+  @Override
+  public int read(@NotNull byte[] b, int off, int len) throws IOException {
+    return cursorStreamDelegate.read(b, off, len);
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    return cursorStreamDelegate.skip(n);
+  }
+
+  @Override
+  public int available() throws IOException {
+    return cursorStreamDelegate.available();
+  }
+
+  @Override
+  public void close() throws IOException {
+    cursorStreamDelegate.close();
+    cursorStreamDelegateProvider.close();
+  }
+
+  @Override
+  public synchronized void mark(int readlimit) {
+    cursorStreamDelegate.mark(readlimit);
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    cursorStreamDelegate.reset();
+  }
+
+  @Override
+  public boolean markSupported() {
+    return cursorStreamDelegate.markSupported();
+  }
+
+  @Override
+  public int read() throws IOException {
+    return cursorStreamDelegate.read();
+  }
+
+  @Override
+  public long getPosition() {
+    return cursorStreamDelegate.getPosition();
+  }
+
+  @Override
+  public void seek(long position) throws IOException {
+    cursorStreamDelegate.seek(position);
+  }
+
+  @Override
+  public void release() {
+    cursorStreamDelegate.release();
+  }
+
+  @Override
+  public boolean isReleased() {
+    return cursorStreamDelegate.isReleased();
+  }
+
+  @Override
+  public CursorProvider getProvider() {
+    return cursorStreamDelegate.getProvider();
+  }
+}

--- a/src/main/java/org/mule/extension/ws/internal/transport/ExtensionsClientHttpRequestExecutor.java
+++ b/src/main/java/org/mule/extension/ws/internal/transport/ExtensionsClientHttpRequestExecutor.java
@@ -19,7 +19,6 @@ import org.mule.extension.ws.api.transport.HttpRequestResponse;
 import org.mule.runtime.api.metadata.TypedValue;
 import org.mule.runtime.api.streaming.bytes.CursorStreamProvider;
 import org.mule.runtime.api.util.MultiMap;
-import org.mule.runtime.api.util.Pair;
 import org.mule.runtime.extension.api.client.DefaultOperationParameters;
 import org.mule.runtime.extension.api.client.DefaultOperationParametersBuilder;
 import org.mule.runtime.extension.api.client.ExtensionsClient;
@@ -119,7 +118,7 @@ public class ExtensionsClientHttpRequestExecutor {
   private InputStream getContent(Result<Object, Object> result) {
     Object output = result.getOutput();
     if (output instanceof CursorStreamProvider) {
-      return ((CursorStreamProvider) output).openCursor();
+      return new CursorStreamWithProvider(((CursorStreamProvider) output).openCursor(), (CursorStreamProvider) output);
     } else if (output instanceof InputStream) {
       return (InputStream) output;
     } else {


### PR DESCRIPTION
If merged, this commit add a CursorStream wrapper that mantains a CursorStream
delegate and the delegate ManagedCursorStreamProvider. In this way we keep a hard
reference to the CursorStreamProvider and avoid the runtime to close the CursorStream