### PR TITLE
WSC111: Added tests for the fix added in mule-soap-engine

### DIFF
--- a/src/test/munit/attachment/attachments-test-case.xml
+++ b/src/test/munit/attachment/attachments-test-case.xml
@@ -83,6 +83,42 @@
                     <munit:parameter propertyName="attachmentName" value="attachment" />
                 </munit:parameters>
             </munit:parameterization>
+            <munit:parameterization name="MTOMEnabled_NotMtomResponse_SOAP11">
+                <munit:parameters>
+                    <munit:parameter propertyName="soapVersion" value="SOAP11"/>
+                    <munit:parameter propertyName="wsPort" value="${WS_SOAP11_PORT}"/>
+                    <munit:parameter propertyName="mtomEnabled" value="true"/>
+                    <munit:parameter propertyName="config" value="default-config" />
+                    <munit:parameter propertyName="attachmentName" value="attachment" />
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="MTOMDisabled_MTOMResponse_SOAP11">
+                <munit:parameters>
+                    <munit:parameter propertyName="soapVersion" value="SOAP11"/>
+                    <munit:parameter propertyName="wsPort" value="${WS_SOAP11_PORT}"/>
+                    <munit:parameter propertyName="mtomEnabled" value="false"/>
+                    <munit:parameter propertyName="config" value="default-config" />
+                    <munit:parameter propertyName="attachmentName" value="attachment.txt" />
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="MTOMEnabled_NotMtomResponse_SOAP12">
+                <munit:parameters>
+                    <munit:parameter propertyName="soapVersion" value="SOAP12"/>
+                    <munit:parameter propertyName="wsPort" value="${WS_SOAP12_PORT}"/>
+                    <munit:parameter propertyName="mtomEnabled" value="true"/>
+                    <munit:parameter propertyName="config" value="default-config" />
+                    <munit:parameter propertyName="attachmentName" value="attachment" />
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="MTOMDisabled_MTOMResponse_SOAP12">
+                <munit:parameters>
+                    <munit:parameter propertyName="soapVersion" value="SOAP12"/>
+                    <munit:parameter propertyName="wsPort" value="${WS_SOAP12_PORT}"/>
+                    <munit:parameter propertyName="mtomEnabled" value="false"/>
+                    <munit:parameter propertyName="config" value="default-config" />
+                    <munit:parameter propertyName="attachmentName" value="attachment.txt" />
+                </munit:parameters>
+            </munit:parameterization>
         </munit:parameterizations>
     </munit:config>
 


### PR DESCRIPTION
It is verified that the mtom setting (on / off) is only respected when the message is an outgoing message.
These tests run in a soapui project with the following configuration.
If the server receives an attachment called "attachment.txt", it will respond with an mtom message with an attachment.
If the server receives a message with an attachment called "attachment" (without ".txt"), it will reply with a message with the attachment encoded, that is, without mtom.