### PR TITLE
W-12637413: Release WSCC 1.8.1 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <groupId>org.mule.connectors</groupId>
     <artifactId>mule-wsc-connector</artifactId>
     <packaging>mule-extension</packaging>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.8.1</version>
 
     <name>Web Service Consumer Connector</name>
     <description>A Mule connector that provides functionality for dynamically consuming SOAP web services</description>


### PR DESCRIPTION
_Hi, thank you for your work. We understand that you want to merge your changes and move on from this issue, but we also want to maintain the safety, readability, and testability of our code. Because of this, we kindly ask that you confirm that you have fulfilled the prerequisites for each category of activity before merging your changes._

### For ALL the Releases:

- [ ] There is a task in GUS for this change.
- [ ] The corresponding Release Notes have been written and shared with the documentation team.
- [ ] The new code has tests and they have before and after methods to be sure that you are working with a clean environment and that you are leaving the environment clean after they finish.
- [ ] If you are using reflection, create a test to call the methods you are invoking, this way, if there is a change in the API, the test will be able to detect it.
- [ ] If the project has a parent pom and modules, the release pipeline only uploads the modules, so, please, make sure that the parent was deployed in the repositories before considering this release finished.
- [ ] Notify in the Slack Channel that the release is complete, so the Docs team can merge the Documentation and Release Notes PR. The docs team always checks in Anypoint Exchange that the connector is released before merging the release notes.
- [ ] Add the connector build to GUS, and assign that build to the GUS ticket.
- [ ] Create a change case request, based on the Change Case Management doc https://docs.google.com/document/d/1tMJlTTZLaXMLiYwxlMBFY1yJwBmejhc4-IP8HAXgDfY/edit#

**NOTE**: _(applies only for Core-Connectors connectors and modules) The release process ends when you merge the pull request that updates the support branch to the new snapshot, please don't forget to do this._

### Patch Version:

- [ ] The Pull Request has been peer-reviewed.
- [ ] No backward compatibility is broken.
- [ ] Documentation: (Required) Release Notes PR with compatibility table. Share it with the Docs team.

