### PR TITLE
W-12655484: We went back to munit.extensions.maven.plugin 1.1.2 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <mavenResourcesVersion>3.3.0</mavenResourcesVersion>
         <munit.version>2.3.13</munit.version>
         <mtf.tools.version>1.1.2</mtf.tools.version>
-        <munit.extensions.maven.plugin.version>1.1.3</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.1.2</munit.extensions.maven.plugin.version>
 
         <validations.module.version>1.1.0</validations.module.version>
         <java.module.version>1.1.1</java.module.version>


### PR DESCRIPTION
We went back to munit.extensions.maven.plugin 1.1.2 version because there are test that fail with the new one


### For ALL the Releases:
- [ ] There is a task in GUS for this change.
- [ ] The new code has tests and they have before and after methods to be sure that you are working with a clean environment and that you are leaving the environment clean after they finish.



